### PR TITLE
fix: no need to check for permissions for changelog page

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1284,12 +1284,12 @@ class SourceChangelogView(WaffleFlagMixin, DetailView):
         return ctx
 
     def get_object(self, queryset=None):
-        dataset = find_dataset(self.kwargs["dataset_uuid"], self.request.user)
         if self.kwargs["model_class"] == ReferenceDataset:
-            return dataset
+            return get_object_or_404(ReferenceDataset, uuid=self.kwargs["dataset_uuid"])
+
         return get_object_or_404(
             self.kwargs["model_class"],
-            dataset=dataset,
+            dataset_id=self.kwargs["dataset_uuid"],
             pk=self.kwargs["source_id"],
         )
 


### PR DESCRIPTION
### Description of change

Fixes the issue where admins could not see the changelog page unless they had permission to the dataset itself. The long term goal is top open this page up to all users so this is the next step along that path (it's currently behind a feature flag).

### Checklist

* [ ] Have tests been added to cover any changes?
