### PR TITLE
fix: correct reference table event logging

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/templatetags/core_tags.py
+++ b/dataworkspace/dataworkspace/apps/core/templatetags/core_tags.py
@@ -3,6 +3,7 @@ import re
 
 from django import template
 from django.utils.html import format_html
+from django.urls import reverse
 
 register = template.Library()
 
@@ -67,3 +68,8 @@ def spawner_cpu(value):
 def browser_is_internet_explorer(context, **kwargs):
     user_agent = context["request"].META.get("HTTP_USER_AGENT", "")
     return re.search(r"MSIE|Trident/7\.0; rv:\d+", user_agent) is not None
+
+
+@register.simple_tag
+def send_post_data_url(dataset_uuid, data_type):
+    return reverse("datasets:reference_dataset_download", args=(dataset_uuid, data_type))

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -18,7 +18,7 @@ from psycopg2 import sql
 from botocore.exceptions import ClientError
 from ckeditor.fields import RichTextField
 
-from django import forms
+from django import forms, template
 from django.apps import apps
 from django.db import (
     DatabaseError,
@@ -76,6 +76,7 @@ from dataworkspace.datasets_db import (
     get_earliest_tables_last_updated_date,
 )
 
+register = template.Library()
 
 class DataGroupingManager(DeletableQuerySet):
     def with_published_datasets(self):
@@ -1334,9 +1335,6 @@ class ReferenceDataset(DeletableTimestampedUserModel):
                 self.published_minor_version += 1
             self.major_version = self.published_major_version
             self.minor_version = self.published_minor_version
-
-    def send_post_data_url(self):
-        return reverse("datasets:reference_dataset_download", args=(self.uuid, "csv"))
 
     @transaction.atomic
     def save(self, force_insert=False, force_update=False, using=None, update_fields=None):

--- a/dataworkspace/dataworkspace/apps/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/urls.py
@@ -56,8 +56,8 @@ urlpatterns = [
         name="reference_dataset_grid",
     ),
     path(
-        "<uuid:dataset_uuid>/reference/<str:format>/download",
-        login_required(views.ReferenceDatasetDownloadView.as_view()),
+        "<uuid:dataset_uuid>/reference/<str:data_type>/download",
+        login_required(views.reference_dataset_download),
         name="reference_dataset_download",
     ),
     path(

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -670,20 +670,19 @@ def unset_bookmark(request, dataset_uuid):
     return HttpResponse(status=200)
 
 
-class ReferenceDatasetDownloadView(DetailView):
-    def post(self, request, *args, **kwargs):
-        dataset = find_dataset(self.kwargs.get("dataset_uuid"), request.user, ReferenceDataset)
-        log_event(
-            request.user,
-            EventLog.TYPE_REFERENCE_DATASET_DOWNLOAD,
-            dataset,
-            extra={
-                "path": request.get_full_path(),
-                "reference_dataset_version": dataset.published_version,
-                "format": self.kwargs.get("format"),
-            },
-        )
-        return HttpResponse(status=200)
+def reference_dataset_download(request, dataset_uuid, data_type):
+    dataset = find_dataset(dataset_uuid, request.user, ReferenceDataset)
+    log_event(
+        request.user,
+        EventLog.TYPE_REFERENCE_DATASET_DOWNLOAD,
+        dataset,
+        extra={
+            "path": request.get_full_path(),
+            "reference_dataset_version": dataset.published_version,
+            "format": data_type,
+        },
+    )
+    return HttpResponse(status=200)
 
 
 class SourceLinkDownloadView(DetailView):

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -964,7 +964,7 @@ class ReferenceDatasetGridView(View):
         dataset = find_dataset(dataset_uuid, request.user, ReferenceDataset)
         log_event(
             request.user,
-            EventLog.TYPE_REFERENCE_DATASET_VIEW,
+            EventLog.TYPE_DATA_TABLE_VIEW,
             dataset,
             extra={
                 "path": request.get_full_path(),

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -326,6 +326,13 @@ function initDataGrid(
         linkElement.setAttribute("href", dataUri);
         linkElement.setAttribute("download", exportFileDefaultName);
         linkElement.click();
+        if (referenceDataEndpoint) {
+          var xhr = new XMLHttpRequest();
+          xhr.open("POST", referenceDataEndpoint, true);
+          xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+          xhr.setRequestHeader("X-CSRFToken", getCsrfToken());
+          xhr.send();
+        }
         logDownloadEvent(
           gridOptions,
           itemId,
@@ -340,14 +347,6 @@ function initDataGrid(
         return;
       });
     }
-  }
-
-  if (referenceDataEndpoint) {
-    var xhr = new XMLHttpRequest();
-    xhr.open("POST", referenceDataEndpoint, true);
-    xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
-    xhr.setRequestHeader("X-CSRFToken", getCsrfToken());
-    xhr.send();
   }
 
   var createChartButton = document.querySelector("#data-grid-create-chart");

--- a/dataworkspace/dataworkspace/static/rich-text.css
+++ b/dataworkspace/dataworkspace/static/rich-text.css
@@ -1,0 +1,1 @@
+.govuk-form-group .ck-editor{width:100%}.govuk-form-group .ck-editor .ck-content{font-size:19px;font-family:arial, sans-serif}.govuk-form-group .ck-editor .ck-content pre code{display:inline;overflow-x:visible;overflow-y:visible;max-height:none;background-color:rgba(0,0,0,0);margin-bottom:0}.app-rich-text pre code{margin-bottom:20px}

--- a/dataworkspace/dataworkspace/templates/datasets/reference_dataset_grid.html
+++ b/dataworkspace/dataworkspace/templates/datasets/reference_dataset_grid.html
@@ -24,7 +24,7 @@
         JSON.parse(document.getElementById('grid_data').textContent),
         '{{ model.slug }}-{{ model.published_version }}-custom-export.csv',
         null,
-        '{{ model.send_post_data_url}}',
+        {% send_post_data_url model.id 'json123' %},
         '{{ model.id }}',
         '{{ model.name }}',
         '{{ model.get_type_display }}',


### PR DESCRIPTION
### Description of change
Two events are logged when data preview screen loads (“Reference dataset view” which is incorrect and “Reference dataset download” which is also incorrect). This is a PR to ensure that an event is only logged once and the download event is only logged once a user has executed a download.

### Checklist

* [ ] Have tests been added to cover any changes?
