### PR TITLE
add catalogue editors to Catalogue detail page

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -611,9 +611,12 @@ class DatasetDetailView(DetailView):
                     strip=True,
                 )
             )
+
         ctx["model"] = self.object
         ctx["DATASET_CHANGELOG_PAGE_FLAG"] = settings.DATASET_CHANGELOG_PAGE_FLAG
         ctx["DATA_UPLOADER_UI_FLAG"] = settings.DATA_UPLOADER_UI_FLAG
+        if not self._is_reference_dataset():
+            ctx["data_catalogue_editors"] = self.object.data_catalogue_editors.all()
 
         if self._is_reference_dataset():
             return self._get_context_data_for_reference_dataset(ctx, **kwargs)

--- a/dataworkspace/dataworkspace/templates/partials/contact_catalogue_editors.html
+++ b/dataworkspace/dataworkspace/templates/partials/contact_catalogue_editors.html
@@ -1,0 +1,16 @@
+{% if as_section %}
+<h2 class="govuk-heading-l">Contact</h2>
+<p class="govuk-body">
+  Use this contact to ask questions about this data and how to use it.
+</p>
+{% endif %}
+
+{% for editor in data_catalogue_editors %}
+<p class="govuk-body">
+    {{ editor.first_name }} {{ editor.last_name }}
+    {% if editor.email %}
+        <br/>
+        <a class="govuk-link" href="mailto:{{ editor.email }}">{{ editor.email }}</a>
+    {% endif %}
+</p>
+{% endfor %}

--- a/dataworkspace/dataworkspace/templates/partials/dataset_info_additional.html
+++ b/dataworkspace/dataworkspace/templates/partials/dataset_info_additional.html
@@ -48,12 +48,14 @@
           {% include 'partials/contact.html' with model=model.information_asset_owner %}
         </dd>
       </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Catalogue Editor</dt>
-        <dd class="govuk-summary-list__value">
-          {% include 'partials/contact.html' with model=(data_catalogue_editor for data_catalogue_editor in model.data_catalogue_editors) %}
-        </dd>
-      </div>
+      {% if data_catalogue_editors %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Catalogue Editors</dt>
+          <dd class="govuk-summary-list__value">
+            {% include 'partials/contact_catalogue_editors.html' with editors=data_catalogue_editors %}
+          </dd>
+        </div>
+      {% endif %}
     </dl>
   </div>
 </details>

--- a/dataworkspace/dataworkspace/templates/partials/dataset_info_additional.html
+++ b/dataworkspace/dataworkspace/templates/partials/dataset_info_additional.html
@@ -48,7 +48,12 @@
           {% include 'partials/contact.html' with model=model.information_asset_owner %}
         </dd>
       </div>
-
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Catalogue Editor</dt>
+        <dd class="govuk-summary-list__value">
+          {% include 'partials/contact.html' with model=(data_catalogue_editor for data_catalogue_editor in model.data_catalogue_editors) %}
+        </dd>
+      </div>
     </dl>
   </div>
 </details>


### PR DESCRIPTION
### Description of change
This PR lists all catalogue editors under Additional Information section within Catalogue detail page. Skips for Reference Dataset as there is no field for catalogue editors.

### Checklist

* [ ] Have tests been added to cover any changes?
