### PR TITLE
Skip tools access request for source data set

### DIFF
--- a/dataworkspace/dataworkspace/apps/request_access/views.py
+++ b/dataworkspace/dataworkspace/apps/request_access/views.py
@@ -38,8 +38,6 @@ class DatasetAccessRequest(CreateView):
         context = super().get_context_data(**kwargs)
         context["catalogue_item"] = catalogue_item
         context["is_visualisation"] = isinstance(catalogue_item, VisualisationCatalogueItem)
-        context["is_data_cut"] = catalogue_item.type == DataSetType.DATACUT
-        context["is_source_set"] = catalogue_item.type == DataSetType.MASTER
         context["user_has_tools_access"] = user_has_tools_access
         context["eligibility_criteria_not_met"] = (
             resolve(self.request.path_info).url_name == "eligibility_criteria_not_met"

--- a/dataworkspace/dataworkspace/apps/request_access/views.py
+++ b/dataworkspace/dataworkspace/apps/request_access/views.py
@@ -38,6 +38,8 @@ class DatasetAccessRequest(CreateView):
         context = super().get_context_data(**kwargs)
         context["catalogue_item"] = catalogue_item
         context["is_visualisation"] = isinstance(catalogue_item, VisualisationCatalogueItem)
+        context["is_data_cut"] = catalogue_item.type == DataSetType.DATACUT
+        context["is_source_set"] = catalogue_item.type == DataSetType.MASTER
         context["user_has_tools_access"] = user_has_tools_access
         context["eligibility_criteria_not_met"] = (
             resolve(self.request.path_info).url_name == "eligibility_criteria_not_met"
@@ -92,6 +94,7 @@ class DatasetAccessRequest(CreateView):
         if user_has_tools_access or catalogue_item.type in [
             DataSetType.VISUALISATION,
             DataSetType.DATACUT,
+            DataSetType.MASTER,
         ]:
             return HttpResponseRedirect(
                 reverse("request-access:summary-page", kwargs={"pk": access_request.pk})

--- a/dataworkspace/dataworkspace/tests/request_access/test_views.py
+++ b/dataworkspace/dataworkspace/tests/request_access/test_views.py
@@ -361,7 +361,7 @@ class TestDatasetAndToolsAccess:
         resp = client.get(reverse("request_access:dataset", kwargs={"dataset_uuid": dataset.id}))
         assert "Continue" in resp.content.decode(resp.charset)
 
-    def test_user_redirected_to_tools_form_after_dataset_request_access_form_submission(
+    def test_user_redirected_to_summary_after_dataset_request_access_form_submission(
         self, client, metadata_db
     ):
         dataset = DatasetsCommon()._create_master(
@@ -379,7 +379,9 @@ class TestDatasetAndToolsAccess:
         assert access_requests[0].reason_for_access == "I need it"
         assert access_requests[0].journey == AccessRequest.JOURNEY_DATASET_ACCESS
         assert resp.status_code == 302
-        assert resp.url == reverse("request_access:tools-1", kwargs={"pk": access_requests[0].pk})
+        assert resp.url == reverse(
+            "request_access:summary-page", kwargs={"pk": access_requests[0].pk}
+        )
 
     def test_tools_not_required_for_data_cut(self, client, metadata_db):
         datacut = DataSetFactory.create(


### PR DESCRIPTION
### Description of change
Tool access is not mandatory for source dataset. If the access request is for a source set then it now redirects to the summary page instead of continuing to the request tools page.

### Checklist

* [x] Have tests been added to cover any changes?
