### PR TITLE
fix: ensure data explorer can handle interval data types in queries

### DIFF
--- a/dataworkspace/dataworkspace/utils.py
+++ b/dataworkspace/dataworkspace/utils.py
@@ -185,7 +185,7 @@ TYPE_CODES_REVERSED = {
     1183: "time[]",
     1184: "timestamp with time zone",
     1185: "timestamp with time zone[]",
-    1186: "timestamp with time zone",
+    1186: "interval",
     1187: "interval[]",
     1231: "decimal[]",
     1266: "time",


### PR DESCRIPTION
### Description of change

Data explorer was incorrectly expecting a timestamp for columns with an OID of 1186. The correct type for this OID is interval.

### Checklist

* [ ] Have tests been added to cover any changes?
