### PR TITLE
fix: set quicksight email to DW user email when syncing users

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -837,10 +837,15 @@ def create_update_delete_quicksight_user_data_sources(
 def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_list):
     for quicksight_user in quicksight_user_list:
         user_arn = quicksight_user["Arn"]
-        user_email = quicksight_user["Email"].lower()
         user_role = quicksight_user["Role"]
         user_username = quicksight_user["UserName"]
         sso_id = quicksight_user["UserName"].split("/")[-1]
+
+        # Update the quicksight user's email address to match data workspace
+        try:
+            user_email = get_user_model().objects.get(username=sso_id).email
+        except get_user_model().DoesNotExist:
+            user_email = quicksight_user["Email"].lower()
 
         if user_role not in {"AUTHOR", "ADMIN"}:
             logger.info("Skipping %s with role %s.", user_email, user_role)

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -162,8 +162,8 @@ class TestSyncQuickSightPermissions:
     @mock.patch("dataworkspace.apps.applications.utils.cache")
     def test_list_user_pagination(self, mock_cache, mock_boto3_client, mock_creds):
         # Arrange
-        UserFactory.create(username="fake@email.com")
-        UserFactory.create(username="fake2@email.com")
+        UserFactory.create(username="fake@email.com", email="updated@email.com")
+        UserFactory.create(username="fake2@email.com", email="fake2@email.com")
         SourceTableFactory(
             dataset=MasterDataSetFactory.create(
                 user_access_type=UserAccessType.REQUIRES_AUTHENTICATION
@@ -214,7 +214,7 @@ class TestSyncQuickSightPermissions:
                 Role="AUTHOR",
                 CustomPermissionsName="author-custom-permissions-test",
                 UserName="user/fake@email.com",
-                Email="fake@email.com",
+                Email="updated@email.com",
             ),
             mock.call(
                 AwsAccountId=mock.ANY,


### PR DESCRIPTION
### Description of change

Fixes issue where quicksight user emails were never updated and users were not receiving notifications

### Checklist

* [ ] Have tests been added to cover any changes?
