### PR TITLE
feature/DT-1829-refactor-your-files-scheduled-task

### DIFF
--- a/dataworkspace/dataworkspace/apps/your_files/tasks.py
+++ b/dataworkspace/dataworkspace/apps/your_files/tasks.py
@@ -22,82 +22,128 @@ from dataworkspace.cel import celery_app
 logger = logging.getLogger("app")
 
 
-def _collect_your_files_stats():
-    start_time = time.time()
-    client = get_s3_client()
-    paginator = client.get_paginator("list_objects_v2")
-    users_to_update = (
-        get_user_model()
-        .objects.filter(
-            profile__sso_status="active",
-        )
-        .exclude(profile__first_login=None)
-    )
-    logger.info("your_files_stats: Found %d users to collect stats for", users_to_update.count())
-    for user in users_to_update:
-        logger.info("your_files_stats: Collecting stats for user %s", user.email)
-        user_home_prefix = get_s3_prefix(str(user.profile.sso_id))
-        total_size = 0
-        total_files = 0
-        num_large_files = 0
-        for page in paginator.paginate(Bucket=settings.NOTEBOOKS_BUCKET, Prefix=user_home_prefix):
-            for metadata in page.get("Contents", []):
-                if metadata["Key"].startswith(f"{user_home_prefix}bigdata"):
-                    continue
-                total_size += metadata["Size"]
-                total_files += 1
-                if metadata["Size"] / 1e9 > 5:
-                    num_large_files += 1
-
-        if total_files == 0:
-            logger.info(
-                "your_files_stats: User %s has no files stored currently. Skipping", user.email
-            )
-            continue
-
-        try:
-            latest_stat = user.your_files_stats.latest()
-        except YourFilesUserPrefixStats.DoesNotExist:
-            latest_stat = None
-
-        # If we don't have any stats for this user, or the stats have changed since the last run,
-        # create a new record
-        if latest_stat is None or latest_stat.total_size_bytes != total_size:
-            YourFilesUserPrefixStats.objects.create(
-                user=user,
-                prefix=user_home_prefix,
-                total_size_bytes=total_size,
-                num_files=total_files,
-                num_large_files=num_large_files,
-            )
-        # If no change since the last run just update the last checked date
-        elif latest_stat:
-            latest_stat.last_checked_date = datetime.now(tz=pytz.utc)
-            latest_stat.save(update_fields=["last_checked_date"])
-
-        logger.info(
-            "your_files_stats: User %s has %d files with a total size of %d bytes (%d > 5 GB)",
-            user.email,
-            total_files,
-            total_size,
-            num_large_files,
-        )
-
-    logger.info(
-        "your_files_stats: Took %s seconds to gather stats for %d users",
-        round(time.time() - start_time, 2),
-        users_to_update.count(),
-    )
-
-
 @celery_app.task()
 @close_all_connections_if_not_in_atomic_block
-def collect_your_files_stats():
+def collect_your_files_stats_all_users():
     if not waffle.switch_is_active("enable_your_files_stats_collection"):
         logger.info("your_files_stats: Skipping run as waffle switch is inactive")
         return
     try:
+        start_time = time.time()
         with cache.lock("your_files_stats", blocking_timeout=0, timeout=1800):
-            _collect_your_files_stats()
+            paginator = _get_s3_list_objects_paginator()
+            users_to_update = (
+                get_user_model()
+                .objects.filter(
+                    profile__sso_status="active",
+                )
+                .exclude(profile__first_login=None)
+            )
+            logger.info(
+                "your_files_stats: Found %d users to collect stats for", users_to_update.count()
+            )
+            for user in users_to_update:
+                with _get_user_cache_lock(user.id):
+                    _sync_user_storage(user, paginator)
+
+            logger.info(
+                "your_files_stats: Took %s seconds to gather stats for %d users",
+                round(time.time() - start_time, 2),
+                users_to_update.count(),
+            )
+
     except redis.exceptions.LockError:
         logger.info("your_files_stats: Unable to acquire lock to sync your files stats")
+
+
+@celery_app.task()
+@close_all_connections_if_not_in_atomic_block
+def collect_your_files_stats_single_user(user_id):
+    if not waffle.switch_is_active("enable_your_files_stats_collection"):
+        logger.info("your_files_stats: Skipping run as waffle switch is inactive")
+        return
+    try:
+        with _get_user_cache_lock(user_id):
+            paginator = _get_s3_list_objects_paginator()
+            user = (
+                get_user_model()
+                .objects.filter(id=user_id, profile__sso_status="active")
+                .exclude(profile__first_login=None)
+                .first()
+            )
+
+            if user is None:
+                logger.info("your_files_stats: Skipping user as they are not active")
+                return
+
+            _sync_user_storage(user, paginator)
+
+    except redis.exceptions.LockError as exc:
+        print(exc)
+        logger.info("your_files_stats: Unable to acquire lock to sync user your files stats")
+
+
+def _get_s3_list_objects_paginator():
+    client = get_s3_client()
+    return client.get_paginator("list_objects_v2")
+
+
+def _get_user_cache_lock(user_id):
+    return cache.lock(f"your_files_stats_{user_id}", blocking_timeout=0, timeout=300)
+
+
+def _sync_user_storage(user, paginator):
+    start_time = time.time()
+
+    logger.info("your_files_stats: Collecting stats for user %s", user.email)
+
+    user_home_prefix = get_s3_prefix(str(user.profile.sso_id))
+    total_size = 0
+    total_files = 0
+    num_large_files = 0
+    for page in paginator.paginate(Bucket=settings.NOTEBOOKS_BUCKET, Prefix=user_home_prefix):
+        for metadata in page.get("Contents", []):
+            if metadata["Key"].startswith(f"{user_home_prefix}bigdata"):
+                continue
+            total_size += metadata["Size"]
+            total_files += 1
+            if metadata["Size"] / 1e9 > 5:
+                num_large_files += 1
+    if total_files == 0:
+        logger.info(
+            "your_files_stats: User %s has no files stored currently. Skipping", user.email
+        )
+        return
+
+    try:
+        latest_stat = user.your_files_stats.latest()
+    except YourFilesUserPrefixStats.DoesNotExist:
+        latest_stat = None
+
+    # If we don't have any stats for this user, or the stats have changed since the last run,
+    # create a new record
+    if latest_stat is None or latest_stat.total_size_bytes != total_size:
+        logger.info("your_files_stats: User %s needs a new user stats record created", user.email)
+        YourFilesUserPrefixStats.objects.create(
+            user=user,
+            prefix=user_home_prefix,
+            total_size_bytes=total_size,
+            num_files=total_files,
+            num_large_files=num_large_files,
+        )
+    # If no change since the last run just update the last checked date
+    elif latest_stat:
+        logger.info(
+            "your_files_stats: User %s has no change in files since the last run", user.email
+        )
+        latest_stat.last_checked_date = datetime.now(tz=pytz.utc)
+        latest_stat.save(update_fields=["last_checked_date"])
+
+    logger.info(
+        "your_files_stats: User %s has %d files with a total size of %d bytes (%d > 5 GB). Took %s seconds to process",
+        user.email,
+        total_files,
+        total_size,
+        num_large_files,
+        round(time.time() - start_time, 2),
+    )

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -442,7 +442,7 @@ if not strtobool(env.get("DISABLE_CELERY_BEAT_SCHEDULE", "0")):
             "args": (),
         },
         "your-files-stats-collection": {
-            "task": "dataworkspace.apps.your_files.tasks.collect_your_files_stats",
+            "task": "dataworkspace.apps.your_files.tasks.collect_your_files_stats_all_users",
             "schedule": crontab(minute="30"),
             "args": (),
         },

--- a/dataworkspace/dataworkspace/tests/your_files/test_tasks.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_tasks.py
@@ -3,34 +3,191 @@ from datetime import datetime
 import mock
 import pytest
 
+
+from waffle.testutils import override_switch
+
 from dataworkspace.apps.core.utils import get_s3_prefix
-from dataworkspace.apps.your_files.tasks import _collect_your_files_stats
+from dataworkspace.apps.your_files.tasks import (
+    collect_your_files_stats_all_users,
+    collect_your_files_stats_single_user,
+    _sync_user_storage,
+)
+from dataworkspace.apps.your_files.models import YourFilesUserPrefixStats
 from dataworkspace.tests import factories
 
 
-@pytest.mark.django_db
-@mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
-def test_collect_your_files_stats(mock_client):
+@pytest.fixture
+def active_user():
     user = factories.UserFactory.create()
     user.profile.sso_status = "active"
     user.profile.first_login = datetime.now()
     user.profile.save()
+    return user
 
-    mock_client.return_value.get_paginator.return_value.paginate.return_value = [
-        {
-            "Contents": [
-                {
-                    "Key": f"{get_s3_prefix(str(user.profile.sso_id))}bigdata/test",
-                    "Size": 10,
-                },
-                {
-                    "Key": f"{get_s3_prefix(str(user.profile.sso_id))}/test",
-                    "Size": 10,
-                },
-            ]
-        },
-    ]
 
-    _collect_your_files_stats()
-    assert user.your_files_stats.count() == 1
-    assert user.your_files_stats.latest().total_size_bytes == 10
+@pytest.mark.django_db
+class TestCollectYourFilesStatsAllUsersCeleryTask:
+    @mock.patch("dataworkspace.apps.your_files.tasks._get_s3_list_objects_paginator")
+    @override_switch("enable_your_files_stats_collection", active=False)
+    def test_all_users_your_file_stats_when_waffle_flag_inactive(self, mock_paginator):
+        collect_your_files_stats_all_users()
+        assert not mock_paginator.called
+
+    @mock.patch("dataworkspace.apps.your_files.tasks._get_s3_list_objects_paginator")
+    @override_switch("enable_your_files_stats_collection", active=True)
+    def test_all_users_your_file_stats_when_waffle_flag_active(self, mock_paginator, active_user):
+        collect_your_files_stats_all_users()
+        assert mock_paginator.called
+
+    @mock.patch("dataworkspace.apps.your_files.tasks._sync_user_storage")
+    @override_switch("enable_your_files_stats_collection", active=True)
+    def test_all_users_your_file_stats_when_waffle_flag_active_ignores_inactive_users(
+        self, mock_sync_user_storage, active_user
+    ):
+        inactive_user = factories.UserFactory.create()
+        inactive_user.profile.sso_status = "inactive"
+        inactive_user.profile.first_login = datetime.now()
+        inactive_user.profile.save()
+
+        collect_your_files_stats_all_users()
+        mock_sync_user_storage.assert_called_once_with(active_user, mock.ANY)
+
+    @mock.patch("dataworkspace.apps.your_files.tasks._sync_user_storage")
+    @override_switch("enable_your_files_stats_collection", active=True)
+    def test_all_users_your_file_stats_when_waffle_flag_active_ignores_never_logged_in_users(
+        self, mock_sync_user_storage, active_user
+    ):
+        inactive_user = factories.UserFactory.create()
+        inactive_user.profile.sso_status = "active"
+        inactive_user.profile.first_login = None
+        inactive_user.profile.save()
+
+        collect_your_files_stats_all_users()
+        mock_sync_user_storage.assert_called_once_with(active_user, mock.ANY)
+
+
+@pytest.mark.django_db
+class TestCollectYourFilesStatsSingleUserCeleryTask:
+    @mock.patch("dataworkspace.apps.your_files.tasks._get_s3_list_objects_paginator")
+    @override_switch("enable_your_files_stats_collection", active=False)
+    def test_single_user_your_file_stats_when_waffle_flag_inactive(self, mock_paginator):
+        collect_your_files_stats_single_user(1)
+        assert not mock_paginator.called
+
+    @mock.patch("dataworkspace.apps.your_files.tasks._get_s3_list_objects_paginator")
+    @override_switch("enable_your_files_stats_collection", active=True)
+    def test_single_user_your_file_stats_when_waffle_flag_active(self, mock_paginator):
+        collect_your_files_stats_single_user(1)
+        assert mock_paginator.called
+
+    @mock.patch("dataworkspace.apps.your_files.tasks._sync_user_storage")
+    @override_switch("enable_your_files_stats_collection", active=True)
+    def test_single_user_your_file_stats_with_invalid_user_id(self, mock_sync_user_storage):
+        collect_your_files_stats_single_user(1)
+        assert not mock_sync_user_storage.called
+
+    @mock.patch("dataworkspace.apps.your_files.tasks._sync_user_storage")
+    @override_switch("enable_your_files_stats_collection", active=True)
+    def test_single_user_your_file_stats_with_inactive_user(self, mock_sync_user_storage):
+        inactive_user = factories.UserFactory.create()
+        inactive_user.profile.sso_status = "inactive"
+        inactive_user.profile.first_login = datetime.now()
+        inactive_user.profile.save()
+
+        collect_your_files_stats_single_user(inactive_user.id)
+        assert not mock_sync_user_storage.called
+
+    @mock.patch("dataworkspace.apps.your_files.tasks._sync_user_storage")
+    @override_switch("enable_your_files_stats_collection", active=True)
+    def test_single_user_your_file_stats_with_never_logged_in_user(self, mock_sync_user_storage):
+        inactive_user = factories.UserFactory.create()
+        inactive_user.profile.sso_status = "active"
+        inactive_user.profile.first_login = None
+        inactive_user.profile.save()
+
+        collect_your_files_stats_single_user(inactive_user.id)
+        assert not mock_sync_user_storage.called
+
+    @mock.patch("dataworkspace.apps.your_files.tasks._sync_user_storage")
+    @override_switch("enable_your_files_stats_collection", active=True)
+    def test_single_user_your_file_stats_with_active_user(
+        self, mock_sync_user_storage, active_user
+    ):
+        collect_your_files_stats_single_user(active_user.id)
+        mock_sync_user_storage.assert_called_once_with(active_user, mock.ANY)
+
+
+@pytest.mark.django_db
+class TestSyncUserStorage:
+    def test_user_without_files_returns_without_creating_stats_entry(self, active_user):
+        paginator = mock.MagicMock()
+        paginator.paginate.return_value = [
+            {"Contents": []},
+        ]
+
+        _sync_user_storage(active_user, paginator)
+        assert active_user.your_files_stats.count() == 0
+
+    def test_user_with_only_bigdata_returns_without_creating_stats_entry(self, active_user):
+        paginator = mock.MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {
+                        "Key": f"{get_s3_prefix(str(active_user.profile.sso_id))}bigdata/test",
+                        "Size": 20,
+                    },
+                ]
+            },
+        ]
+
+        _sync_user_storage(active_user, paginator)
+        assert active_user.your_files_stats.count() == 0
+
+    def test_user_with_new_files_creates_new_stats_entry(self, active_user):
+        YourFilesUserPrefixStats.objects.create(
+            user=active_user,
+            prefix="/abc",
+            total_size_bytes=100,
+            num_files=5,
+            num_large_files=0,
+        )
+        paginator = mock.MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {
+                        "Key": f"{get_s3_prefix(str(active_user.profile.sso_id))}/test",
+                        "Size": 55,
+                    },
+                ]
+            },
+        ]
+
+        _sync_user_storage(active_user, paginator)
+        assert active_user.your_files_stats.count() == 2
+        assert active_user.your_files_stats.latest().total_size_bytes == 55
+
+    def test_user_with_no_file_changes_updates_previous_stats_entry(self, active_user):
+        YourFilesUserPrefixStats.objects.create(
+            user=active_user,
+            prefix="/abc",
+            total_size_bytes=55,
+            num_files=1,
+            num_large_files=0,
+        )
+        paginator = mock.MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {
+                        "Key": f"{get_s3_prefix(str(active_user.profile.sso_id))}/test",
+                        "Size": 55,
+                    },
+                ]
+            },
+        ]
+
+        _sync_user_storage(active_user, paginator)
+        assert active_user.your_files_stats.count() == 1
+        assert active_user.your_files_stats.latest().total_size_bytes == 55


### PR DESCRIPTION
### Description of change

- Renamed the original scheduled job to make it obvious it is getting the S3 file size for all users
- Added a new celery job that can be used to sync an individual users S3 filesize
- Used a new lock when dealing with a single user sync, to avoid conflicts if the all users job and single user job is running at the same time
- Added test coverage for the task functions

### Checklist

* [ ] Have tests been added to cover any changes?
