### PR TITLE
DT-1851/Remove focus on modal content

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/partials/dialog.html
+++ b/dataworkspace/dataworkspace/templates/datasets/partials/dialog.html
@@ -32,7 +32,7 @@
   </div>
   <div>
     <h2 class="govuk-heading-l" role="heading">Confirm data download</h2>
-    <div class="govuk-!-padding-bottom-2" tabindex="0">
+    <div class="govuk-!-padding-bottom-2">
       <p class="govuk-body text--margin">
         Downloading this data will create a copy on your device which will no
         longer be updated and can be changed.


### PR DESCRIPTION
### Description of change

This change removes a tabindex attribute from the download dialog to stop it focusing on the content when opened.

### Checklist

* [ ] Have tests been added to cover any changes?
