### PR TITLE
A11y: Move breadcrumbs from main content of data preview pages

### DIFF
--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -104,10 +104,10 @@ function submitFilterForm(action, fileName, gridOptions, columnDataTypeMap) {
   form.remove();
 }
 
-function handleBannerVisibility(isVisible) {
-  var gridSavedBanner = document.getElementById("grid-saved-banner");
-  var dismissBanner = document.getElementById("dismiss-banner");
-  var tabIndexValue = isVisible ? "0" : "-1";
+function showGridNotificationBanner(isVisible) {
+  const gridSavedBanner = document.getElementById("grid-saved-banner");
+  const dismissBanner = document.getElementById("dismiss-banner");
+  const tabIndexValue = isVisible ? "0" : "-1";
 
   if (isVisible) {
     gridSavedBanner.classList.remove("govuk-visually-hidden");
@@ -575,7 +575,7 @@ function initDataGrid(
       xhr.onreadystatechange = function () {
         if (this.readyState === XMLHttpRequest.DONE) {
           if (this.status === 200) {
-            handleBannerVisibility(true);
+            showGridNotificationBanner(true);
           }
           saveViewButton.innerHTML = "Save view";
           saveViewButton.removeAttribute("disabled");
@@ -588,7 +588,7 @@ function initDataGrid(
       .getElementById("dismiss-banner")
       .addEventListener("click", function (e) {
         e.preventDefault();
-        handleBannerVisibility(false);
+        showGridNotificationBanner(false);
       });
   }
 }

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -112,7 +112,6 @@ function showGridNotificationBanner(isVisible) {
   if (isVisible) {
     gridSavedBanner.classList.remove("govuk-visually-hidden");
     gridSavedBanner.setAttribute("role", "alert");
-    gridSavedBanner.focus();
   } else {
     gridSavedBanner.classList.add("govuk-visually-hidden");
     gridSavedBanner.removeAttribute("role");
@@ -120,6 +119,10 @@ function showGridNotificationBanner(isVisible) {
 
   gridSavedBanner.setAttribute("tabindex", tabIndexValue);
   dismissBanner.setAttribute("tabindex", tabIndexValue);
+
+  if (isVisible) {
+    gridSavedBanner.focus();
+  }
 }
 
 function initDataGrid(

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -104,6 +104,24 @@ function submitFilterForm(action, fileName, gridOptions, columnDataTypeMap) {
   form.remove();
 }
 
+function handleBannerVisibility(isVisible) {
+  var gridSavedBanner = document.getElementById("grid-saved-banner");
+  var dismissBanner = document.getElementById("dismiss-banner");
+  var tabIndexValue = isVisible ? "0" : "-1";
+
+  if (isVisible) {
+    gridSavedBanner.classList.remove("govuk-visually-hidden");
+    gridSavedBanner.setAttribute("role", "alert");
+    gridSavedBanner.focus();
+  } else {
+    gridSavedBanner.classList.add("govuk-visually-hidden");
+    gridSavedBanner.removeAttribute("role");
+  }
+
+  gridSavedBanner.setAttribute("tabindex", tabIndexValue);
+  dismissBanner.setAttribute("tabindex", tabIndexValue);
+}
+
 function initDataGrid(
   columnConfig,
   dataEndpoint,
@@ -557,9 +575,7 @@ function initDataGrid(
       xhr.onreadystatechange = function () {
         if (this.readyState === XMLHttpRequest.DONE) {
           if (this.status === 200) {
-            document
-              .getElementById("grid-saved-banner")
-              .classList.remove("govuk-visually-hidden");
+            handleBannerVisibility(true);
           }
           saveViewButton.innerHTML = "Save view";
           saveViewButton.removeAttribute("disabled");
@@ -572,9 +588,7 @@ function initDataGrid(
       .getElementById("dismiss-banner")
       .addEventListener("click", function (e) {
         e.preventDefault();
-        document
-          .getElementById("grid-saved-banner")
-          .classList.add("govuk-visually-hidden");
+        handleBannerVisibility(false);
       });
   }
 }

--- a/dataworkspace/dataworkspace/templates/_main_no_container.html
+++ b/dataworkspace/dataworkspace/templates/_main_no_container.html
@@ -1,5 +1,7 @@
 {% extends '_base_no_footer.html' %}
 
+{% block breadcrumbs %}{% endblock %}
+
 {% block main %}
   <main id="main-content" role="main">
     {% include 'partials/messages.html' %}

--- a/dataworkspace/dataworkspace/templates/datasets/data-preview/data_cut_preview.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data-preview/data_cut_preview.html
@@ -34,38 +34,7 @@
 {% endblock footer_scripts %}
 
 {% block breadcrumbs %}
-  <div class="govuk-breadcrumbs app-grid-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="">Home</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link"
-          href="{% url "datasets:dataset_detail" dataset_uuid=object.dataset.id %}#{{ object.dataset.slug }}">{{ object.dataset.name}}</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" {% if object.name|length > 30 %} title="{{object.name}}" {% endif %}>{{ object.name|truncatechars_html:30  }}</li>
-    </ol>
-    {% flag SECURITY_CLASSIFICATION_FLAG %}
-    <div class="security-classification">
-      {% if not object.dataset.government_security_classification %}
-        <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
-      {% else %}
-        {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
-          <strong
-            class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
-        {% else %}
-          <strong
-            class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
-            {% if object.dataset.sensitivity.all %}
-              {% for sensitivity in object.dataset.sensitivity.all %}
-                {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
-              {% endfor %}
-            {% endif %} </strong>
-        {% endif %}
-      {% endif %}
-    </div>
-    {% endflag %}
-  </div>
+  {% include "datasets/partials/breadcrumbs.html" %}
 {% endblock %}
 
 {% block content %}

--- a/dataworkspace/dataworkspace/templates/datasets/data-preview/data_cut_preview.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data-preview/data_cut_preview.html
@@ -35,6 +35,13 @@
 
 {% block breadcrumbs %}
   {% include "datasets/partials/breadcrumbs.html" %}
+
+  {% if object.dataset.enquiries_contact %}
+    <a class="govuk-link govuk-link--no-visited-state govuk-!-padding-right-3 govuk-!-padding-top-3" style="float: right"
+      href="mailto:{{ object.dataset.enquiries_contact.email }}?subject=Reporting an issue - {{ object.name }}">
+      {% include "partials/icons/report_an_issue_icon.html" with text="Report an issue" %}
+    </a>
+  {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -44,19 +51,13 @@
         {% include "datasets/partials/grid-interaction-disabled.html" %}
       {% endif %}
       {% include "datasets/partials/grid-view-saved.html" %}
-      {% if object.dataset.enquiries_contact %}
-        <a class="govuk-link govuk-link--no-visited-state govuk-!-padding-right-3" style="float: right"
-          href="mailto:{{ object.dataset.enquiries_contact.email }}?subject=Reporting an issue - {{ object.name }}">
-          {% include "partials/icons/report_an_issue_icon.html" with text="Report an issue" %}
-        </a>
-      {% endif %}
       <div class="govuk-!-padding-top-3 govuk-!-padding-left-2">
         <span class="govuk-caption-xl">
           Data table{% if object.schema %} ({{ object.schema }}.{{ object.table }}){% endif %}
         </span>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            <h2 class="govuk-heading-l">{{ object.name }}</h2>
+            <h1 class="govuk-heading-l">{{ object.name }}</h1>
           </div>
             <div class="govuk-grid-column-full">
                 {% if columns or code_snippets and has_access %}

--- a/dataworkspace/dataworkspace/templates/datasets/data-preview/data_cut_preview.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data-preview/data_cut_preview.html
@@ -32,40 +32,44 @@
     );
   </script>
 {% endblock footer_scripts %}
+
+{% block breadcrumbs %}
+  <div class="govuk-breadcrumbs app-grid-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="">Home</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link"
+          href="{% url "datasets:dataset_detail" dataset_uuid=object.dataset.id %}#{{ object.dataset.slug }}">{{ object.dataset.name}}</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" {% if object.name|length > 30 %} title="{{object.name}}" {% endif %}>{{ object.name|truncatechars_html:30  }}</li>
+    </ol>
+    {% flag SECURITY_CLASSIFICATION_FLAG %}
+    <div class="security-classification">
+      {% if not object.dataset.government_security_classification %}
+        <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
+      {% else %}
+        {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
+          <strong
+            class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
+        {% else %}
+          <strong
+            class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
+            {% if object.dataset.sensitivity.all %}
+              {% for sensitivity in object.dataset.sensitivity.all %}
+                {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
+              {% endfor %}
+            {% endif %} </strong>
+        {% endif %}
+      {% endif %}
+    </div>
+    {% endflag %}
+  </div>
+{% endblock %}
+
 {% block content %}
   {% with object.get_metadata_row_count as row_count %}
-    <div class="govuk-breadcrumbs app-grid-breadcrumbs">
-      <ol class="govuk-breadcrumbs__list">
-        <li class="govuk-breadcrumbs__list-item">
-          <a class="govuk-breadcrumbs__link" href="">Home</a>
-        </li>
-        <li class="govuk-breadcrumbs__list-item">
-          <a class="govuk-breadcrumbs__link"
-             href="{% url "datasets:dataset_detail" dataset_uuid=object.dataset.id %}#{{ object.dataset.slug }}">{{ object.dataset.name}}</a>
-        </li>
-        <li class="govuk-breadcrumbs__list-item" {% if object.name|length > 30 %} title="{{object.name}}" {% endif %}>{{ object.name|truncatechars_html:30  }}</li>
-      </ol>
-      {% flag SECURITY_CLASSIFICATION_FLAG %}
-      <div class="security-classification">
-        {% if not object.dataset.government_security_classification %}
-          <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
-        {% else %}
-          {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
-            <strong
-              class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
-          {% else %}
-            <strong
-              class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
-              {% if object.dataset.sensitivity.all %}
-                {% for sensitivity in object.dataset.sensitivity.all %}
-                  {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
-                {% endfor %}
-              {% endif %} </strong>
-          {% endif %}
-        {% endif %}
-      </div>
-    {% endflag %}
-    </div>
     <div id="collapsible-header" class="govuk-!-margin-top-4">
       {% if object.disable_data_grid_interaction %}
         {% include "datasets/partials/grid-interaction-disabled.html" %}

--- a/dataworkspace/dataworkspace/templates/datasets/data-preview/data_sourceset_preview.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data-preview/data_sourceset_preview.html
@@ -34,38 +34,7 @@
 {% endblock footer_scripts %}
 
 {% block breadcrumbs %}
-  <div class="govuk-breadcrumbs govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-bottom-0 app-grid-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="">Home</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link"
-          href="{% url "datasets:dataset_detail" dataset_uuid=object.dataset.id %}#{{ object.dataset.slug }}">{{ object.dataset.name }}</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" {% if object.name|length > 30 %} title="{{object.name}}" {% endif %}>{{ object.name|truncatechars_html:30 }}</li>
-    </ol>
-    {% flag SECURITY_CLASSIFICATION_FLAG %}
-    <div class="security-classification">
-      {% if not object.dataset.government_security_classification %}
-        <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
-      {% else %}
-        {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
-          <strong
-            class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
-        {% else %}
-          <strong
-            class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
-            {% if object.dataset.sensitivity.all %}
-              {% for sensitivity in object.dataset.sensitivity.all %}
-                {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
-              {% endfor %}
-            {% endif %} </strong>
-        {% endif %}
-      {% endif %}
-    </div>
-    {% endflag %}
-  </div>
+{% include "datasets/partials/breadcrumbs.html" %}
 {% endblock %}
 
 {% block content %}

--- a/dataworkspace/dataworkspace/templates/datasets/data-preview/data_sourceset_preview.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data-preview/data_sourceset_preview.html
@@ -32,40 +32,44 @@
     );
   </script>
 {% endblock footer_scripts %}
+
+{% block breadcrumbs %}
+  <div class="govuk-breadcrumbs govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-bottom-0 app-grid-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="">Home</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link"
+          href="{% url "datasets:dataset_detail" dataset_uuid=object.dataset.id %}#{{ object.dataset.slug }}">{{ object.dataset.name }}</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" {% if object.name|length > 30 %} title="{{object.name}}" {% endif %}>{{ object.name|truncatechars_html:30 }}</li>
+    </ol>
+    {% flag SECURITY_CLASSIFICATION_FLAG %}
+    <div class="security-classification">
+      {% if not object.dataset.government_security_classification %}
+        <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
+      {% else %}
+        {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
+          <strong
+            class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
+        {% else %}
+          <strong
+            class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
+            {% if object.dataset.sensitivity.all %}
+              {% for sensitivity in object.dataset.sensitivity.all %}
+                {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
+              {% endfor %}
+            {% endif %} </strong>
+        {% endif %}
+      {% endif %}
+    </div>
+    {% endflag %}
+  </div>
+{% endblock %}
+
 {% block content %}
   {% with object.get_metadata_row_count as row_count %}
-    <div class="govuk-breadcrumbs govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-bottom-0 app-grid-breadcrumbs">
-      <ol class="govuk-breadcrumbs__list">
-        <li class="govuk-breadcrumbs__list-item">
-          <a class="govuk-breadcrumbs__link" href="">Home</a>
-        </li>
-        <li class="govuk-breadcrumbs__list-item">
-          <a class="govuk-breadcrumbs__link"
-             href="{% url "datasets:dataset_detail" dataset_uuid=object.dataset.id %}#{{ object.dataset.slug }}">{{ object.dataset.name }}</a>
-        </li>
-        <li class="govuk-breadcrumbs__list-item" {% if object.name|length > 30 %} title="{{object.name}}" {% endif %}>{{ object.name|truncatechars_html:30 }}</li>
-      </ol>
-      {% flag SECURITY_CLASSIFICATION_FLAG %}
-      <div class="security-classification">
-        {% if not object.dataset.government_security_classification %}
-          <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
-        {% else %}
-          {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
-            <strong
-              class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
-          {% else %}
-            <strong
-              class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
-              {% if object.dataset.sensitivity.all %}
-                {% for sensitivity in object.dataset.sensitivity.all %}
-                  {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
-                {% endfor %}
-              {% endif %} </strong>
-          {% endif %}
-        {% endif %}
-      </div>
-    {% endflag %}
-    </div>
     <div id="collapsible-header" class="govuk-!-margin-top-4">
       {% if object.disable_data_grid_interaction %}
         {% include "datasets/partials/grid-interaction-disabled.html" %}

--- a/dataworkspace/dataworkspace/templates/datasets/data-preview/data_sourceset_preview.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data-preview/data_sourceset_preview.html
@@ -35,6 +35,13 @@
 
 {% block breadcrumbs %}
 {% include "datasets/partials/breadcrumbs.html" %}
+
+{% if object.dataset.enquiries_contact %}
+  <a class="govuk-link govuk-link--no-visited-state govuk-!-padding-right-3 govuk-!-padding-top-3" style="float: right"
+    href="mailto:{{ object.dataset.enquiries_contact.email }}?subject=Reporting an issue - {{ object.name }}">
+    {% include "partials/icons/report_an_issue_icon.html" with text="Report an issue" %}
+  </a>
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -44,19 +51,13 @@
         {% include "datasets/partials/grid-interaction-disabled.html" %}
       {% endif %}
       {% include "datasets/partials/grid-view-saved.html" %}
-      {% if object.dataset.enquiries_contact %}
-        <a class="govuk-link govuk-link--no-visited-state govuk-!-padding-right-3" style="float: right"
-          href="mailto:{{ object.dataset.enquiries_contact.email }}?subject=Reporting an issue - {{ object.name }}">
-          {% include "partials/icons/report_an_issue_icon.html" with text="Report an issue" %}
-        </a>
-      {% endif %}
       <div class="govuk-!-padding-top-3 govuk-!-padding-left-2">
         <span class="govuk-caption-xl">
           Data table{% if object.schema %} ({{ object.schema }}.{{ object.table }}){% endif %}
         </span>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            <h2 class="govuk-heading-l">{{ object.name }}</h2>
+            <h1 class="govuk-heading-l">{{ object.name }}</h1>
           </div>
           <div class="govuk-grid-column-full">
               {% if columns or code_snippets and has_access %}

--- a/dataworkspace/dataworkspace/templates/datasets/data-preview/reference_dataset_preview.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data-preview/reference_dataset_preview.html
@@ -66,22 +66,23 @@
   </div>
   {% endflag %}
 </div>
+
+{% if model.enquiries_contact %}
+  <a href="mailto:{{ model.enquiries_contact.email }}?subject=Reporting an issue - {{ model.name }}"
+      class="govuk-link govuk-link--no-visited-state govuk-!-padding-right-3 govuk-!-padding-top-3" style="float: right">
+      {% include "partials/icons/report_an_issue_icon.html" with text="Report an issue" %}
+  </a>
+{% endif %}
 {% endblock %}
 
 {% block content %}
   <div id="collapsible-header" class="govuk-!-margin-top-4">
       {% include "datasets/partials/grid-view-saved.html" %}
-      {% if model.enquiries_contact %}
-        <a href="mailto:{{ model.enquiries_contact.email }}?subject=Reporting an issue - {{ model.name }}"
-           class="govuk-link govuk-link--no-visited-state govuk-!-padding-right-3" style="float: right">
-           {% include "partials/icons/report_an_issue_icon.html" with text="Report an issue" %}
-        </a>
-      {% endif %}
       <div class="govuk-!-padding-top-4 govuk-!-padding-left-2">
         <span class="govuk-caption-xl">Data table (public.{{ model.table_name }})</span>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">      
-            <h2 class="govuk-heading-l">{{ model.name }} </h2>
+            <h1 class="govuk-heading-l">{{ model.name }} </h1>
           </div>
           <div class="govuk-grid-column-full">
             {% if code_snippets or columns %}

--- a/dataworkspace/dataworkspace/templates/datasets/data-preview/reference_dataset_preview.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data-preview/reference_dataset_preview.html
@@ -31,40 +31,44 @@
     );
   </script>
 {% endblock footer_scripts %}
-{% block content %}
-  <div class="govuk-breadcrumbs govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-bottom-0 app-grid-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="">Home</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link"
-           href="{% url "datasets:dataset_detail" dataset_uuid=model.uuid %}#{{ model.slug }}">{{ model.name }}</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" {% if model.name|length > 30 %} title="{{model.name}}" {% endif %}>{{ model.name|truncatechars_html:30 }}
-      </li>
-    </ol>
-    {% flag SECURITY_CLASSIFICATION_FLAG %}
-    <div class="security-classification">
-    {% if not model.government_security_classification %}
-      <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
+
+{% block breadcrumbs %}
+<div class="govuk-breadcrumbs govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-bottom-0 app-grid-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="">Home</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link"
+         href="{% url "datasets:dataset_detail" dataset_uuid=model.uuid %}#{{ model.slug }}">{{ model.name }}</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item" {% if model.name|length > 30 %} title="{{model.name}}" {% endif %}>{{ model.name|truncatechars_html:30 }}
+    </li>
+  </ol>
+  {% flag SECURITY_CLASSIFICATION_FLAG %}
+  <div class="security-classification">
+  {% if not model.government_security_classification %}
+    <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
+  {% else %}
+    {% if model.get_government_security_classification_display == "OFFICIAL" %}
+      <strong
+        class="govuk-tag govuk-tag--blue">{{ model.get_government_security_classification_display }}</strong>
     {% else %}
-      {% if model.get_government_security_classification_display == "OFFICIAL" %}
-        <strong
-          class="govuk-tag govuk-tag--blue">{{ model.get_government_security_classification_display }}</strong>
-      {% else %}
-        <strong
-          class="govuk-tag govuk-tag--red">{{ model.get_government_security_classification_display }}
-          {% if model.sensitivity.all %}
-            {% for sensitivity in model.sensitivity.all %}
-              {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
-            {% endfor %}
-          {% endif %} </strong>
-      {% endif %}
+      <strong
+        class="govuk-tag govuk-tag--red">{{ model.get_government_security_classification_display }}
+        {% if model.sensitivity.all %}
+          {% for sensitivity in model.sensitivity.all %}
+            {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
+          {% endfor %}
+        {% endif %} </strong>
     {% endif %}
+  {% endif %}
   </div>
-{% endflag %}
-  </div>
+  {% endflag %}
+</div>
+{% endblock %}
+
+{% block content %}
   <div id="collapsible-header" class="govuk-!-margin-top-4">
       {% include "datasets/partials/grid-view-saved.html" %}
       {% if model.enquiries_contact %}

--- a/dataworkspace/dataworkspace/templates/datasets/partials/breadcrumbs.html
+++ b/dataworkspace/dataworkspace/templates/datasets/partials/breadcrumbs.html
@@ -1,0 +1,33 @@
+{% load waffle_tags %}
+<div class="govuk-breadcrumbs govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-bottom-0 app-grid-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="">Home</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link"
+        href="{% url "datasets:dataset_detail" dataset_uuid=object.dataset.id %}#{{ object.dataset.slug }}">{{ object.dataset.name }}</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item" {% if object.name|length > 30 %} title="{{object.name}}" {% endif %}>{{ object.name|truncatechars_html:30 }}</li>
+  </ol>
+  {% flag SECURITY_CLASSIFICATION_FLAG %}
+  <div class="security-classification">
+    {% if not object.dataset.government_security_classification %}
+      <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
+    {% else %}
+      {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
+        <strong
+          class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
+      {% else %}
+        <strong
+          class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
+          {% if object.dataset.sensitivity.all %}
+            {% for sensitivity in object.dataset.sensitivity.all %}
+              {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
+            {% endfor %}
+          {% endif %} </strong>
+      {% endif %}
+    {% endif %}
+  </div>
+  {% endflag %}
+</div>

--- a/dataworkspace/dataworkspace/templates/datasets/partials/grid-view-saved.html
+++ b/dataworkspace/dataworkspace/templates/datasets/partials/grid-view-saved.html
@@ -1,7 +1,6 @@
 <div id="grid-saved-banner" class="grid-view-saved-banner govuk-!-margin-3 govuk-visually-hidden">
   <div
     class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-4"
-    role="alert"
     aria-labelledby="govuk-notification-banner-title"
     data-module="govuk-notification-banner"
   >
@@ -20,6 +19,7 @@
             id="dismiss-banner"
             class="govuk-link govuk-link--no-visited-state"
             href="#"
+            tabindex="-1"
           >
             Dismiss
           </a>


### PR DESCRIPTION
### Description of change
Moved the breadcrumbs for all data preview pages outside of the main content block. This is so that the 'Skip to content' highlights the actual main content and not the breadcrumbs.
Also fixed the save grid banner as it was selectable when tabbing despite being hidden. It now is only selectable when visible and the focus will switch to the banner when it becomes visible

### Checklist

* [ ] Have tests been added to cover any changes?
