### PR TITLE
chore: fix local Superset profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     env_file:
       - .envs/superset.dev.env
     volumes:
-      - ./data-workspace-superset/superset_config.py:/etc/superset/superset_config.py
+      - ../data-workspace-superset/superset_config.py:/etc/superset/superset_config.py
 
   # Test profile services
 


### PR DESCRIPTION
### Description of change

The path to the sibling directory where Superset is expected to be found when developing locally was incorrect.

### Checklist

* [ ] Have tests been added to cover any changes?
