### PR TITLE
bugfix/DT-1842-p-tag-visible

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -1191,6 +1191,7 @@ def get_recently_viewed_catalogue_pages(request):
             )
     return user_event_choice_list
 
+
 def clean_dataset_restrictions_on_usage(dataset):
     if dataset.restrictions_on_usage is not None:
         allowed_tags = bleach.ALLOWED_TAGS + ["a"]

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -5,7 +5,6 @@ from collections import defaultdict, namedtuple
 from itertools import chain
 from typing import Set
 
-import bleach
 import psycopg2
 import waffle
 from botocore.exceptions import ClientError
@@ -41,7 +40,6 @@ from django.http import (
 )
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from django.utils.safestring import mark_safe
 from django.utils.decorators import method_decorator
 from django.views.decorators.http import (
     require_GET,
@@ -642,7 +640,7 @@ class DatasetDetailView(DetailView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data()
         clean_dataset_restrictions_on_usage(self.object)
-                
+
         ctx["model"] = self.object
         ctx["DATASET_CHANGELOG_PAGE_FLAG"] = settings.DATASET_CHANGELOG_PAGE_FLAG
         ctx["DATA_UPLOADER_UI_FLAG"] = settings.DATA_UPLOADER_UI_FLAG
@@ -696,9 +694,9 @@ def eligibility_criteria_view(request, dataset_uuid):
                 url = reverse("datasets:eligibility_criteria_not_met", args=[dataset_uuid])
 
             return HttpResponseRedirect(url)
-        
-    clean_dataset_restrictions_on_usage(dataset)    
-        
+
+    clean_dataset_restrictions_on_usage(dataset)
+
     return render(
         request,
         "eligibility_criteria.html",

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -106,6 +106,7 @@ from dataworkspace.apps.datasets.permissions.utils import (
 from dataworkspace.apps.datasets.search import search_for_datasets
 from dataworkspace.apps.datasets.utils import (
     build_filtered_dataset_query,
+    clean_dataset_restrictions_on_usage,
     dataset_type_to_manage_unpublished_permission_codename,
     find_dataset,
     get_code_snippets_for_table,
@@ -640,18 +641,8 @@ class DatasetDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data()
-        if self.object.restrictions_on_usage is not None:
-            allowed_tags = bleach.ALLOWED_TAGS + ["a"]
-            allowed_attrs = bleach.ALLOWED_ATTRIBUTES.copy()
-            allowed_attrs["a"] = ["href", "class"]
-            self.object.restrictions_on_usage = mark_safe(
-                bleach.clean(
-                    self.object.restrictions_on_usage,
-                    tags=allowed_tags,
-                    attributes=allowed_attrs,
-                    strip=True,
-                )
-            )
+        clean_dataset_restrictions_on_usage(self.object)
+                
         ctx["model"] = self.object
         ctx["DATASET_CHANGELOG_PAGE_FLAG"] = settings.DATASET_CHANGELOG_PAGE_FLAG
         ctx["DATA_UPLOADER_UI_FLAG"] = settings.DATA_UPLOADER_UI_FLAG
@@ -705,7 +696,9 @@ def eligibility_criteria_view(request, dataset_uuid):
                 url = reverse("datasets:eligibility_criteria_not_met", args=[dataset_uuid])
 
             return HttpResponseRedirect(url)
-
+        
+    clean_dataset_restrictions_on_usage(dataset)    
+        
     return render(
         request,
         "eligibility_criteria.html",

--- a/dataworkspace/dataworkspace/tests/datasets/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_utils.py
@@ -2105,21 +2105,21 @@ class TestStoreReferenceDatasetMetadata:
         )
 
 
-class TestCleanDatasetRestrictionsOnUsage():
+class TestCleanDatasetRestrictionsOnUsage:
     def test_when_restrictions_on_usage_is_none_no_changes_made(self):
         dataset = MagicMock()
         dataset.restrictions_on_usage = None
         clean_dataset_restrictions_on_usage(dataset)
         assert dataset.restrictions_on_usage is None
-        
+
     def test_when_restrictions_on_usage_contain_valid_tags_they_remain(self):
         dataset = MagicMock()
-        dataset.restrictions_on_usage = '<a>Hello</a>'
+        dataset.restrictions_on_usage = "<a>Hello</a>"
         clean_dataset_restrictions_on_usage(dataset)
-        assert dataset.restrictions_on_usage == '<a>Hello</a>'
-        
+        assert dataset.restrictions_on_usage == "<a>Hello</a>"
+
     def test_when_restrictions_on_usage_contain_invalid_tags_they_are_removed(self):
         dataset = MagicMock()
-        dataset.restrictions_on_usage = '<p><a>Hello</a></p>'
+        dataset.restrictions_on_usage = "<p><a>Hello</a></p>"
         clean_dataset_restrictions_on_usage(dataset)
-        assert dataset.restrictions_on_usage == '<a>Hello</a>'
+        assert dataset.restrictions_on_usage == "<a>Hello</a>"

--- a/dataworkspace/dataworkspace/tests/datasets/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_utils.py
@@ -16,6 +16,7 @@ from dataworkspace.apps.datasets.models import (
     UserNotification,
 )
 from dataworkspace.apps.datasets.utils import (
+    clean_dataset_restrictions_on_usage,
     dataset_type_to_manage_unpublished_permission_codename,
     get_code_snippets_for_query,
     get_code_snippets_for_table,
@@ -2102,3 +2103,23 @@ class TestStoreReferenceDatasetMetadata:
             '[["link", "integer"], ["field1", "integer"]]',
             "\\x6777518eb5a5d30aa2e7267bdb11bb60",
         )
+
+
+class TestCleanDatasetRestrictionsOnUsage():
+    def test_when_restrictions_on_usage_is_none_no_changes_made(self):
+        dataset = MagicMock()
+        dataset.restrictions_on_usage = None
+        clean_dataset_restrictions_on_usage(dataset)
+        assert dataset.restrictions_on_usage is None
+        
+    def test_when_restrictions_on_usage_contain_valid_tags_they_remain(self):
+        dataset = MagicMock()
+        dataset.restrictions_on_usage = '<a>Hello</a>'
+        clean_dataset_restrictions_on_usage(dataset)
+        assert dataset.restrictions_on_usage == '<a>Hello</a>'
+        
+    def test_when_restrictions_on_usage_contain_invalid_tags_they_are_removed(self):
+        dataset = MagicMock()
+        dataset.restrictions_on_usage = '<p><a>Hello</a></p>'
+        clean_dataset_restrictions_on_usage(dataset)
+        assert dataset.restrictions_on_usage == '<a>Hello</a>'


### PR DESCRIPTION
### Description of change
Use the clean function to remove the `<p>` tags from the restrictions_on_usage property


![image](https://github.com/uktrade/data-workspace-frontend/assets/102232401/99acefe6-046f-47d6-a475-d1ce3f4ca108)

### Checklist

* [ ] Have tests been added to cover any changes?
