### PR TITLE
chore/use-latest-circle-versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.18
           docker_layer_caching: true
       - run:
           name: Build docker containers
@@ -49,7 +48,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.18
           docker_layer_caching: true
       - run:
           name: Build docker containers


### PR DESCRIPTION
### Description of change
Switch the circle ci jobs to use the latest docker versions, the versions we are currently using have been deprecated and removed from circle

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?