### PR TITLE
feature/DT-1857-request-form-field-confusing

### DIFF
--- a/cypress/a11y/collections/request-access.cy.ts
+++ b/cypress/a11y/collections/request-access.cy.ts
@@ -1,0 +1,12 @@
+import { personalCollection } from "../../fixtures/collections";
+
+describe("Request access to collections page", () => {
+  beforeEach(() => {
+    cy.visit(`/collections/${personalCollection}/request_collection_access`);
+    cy.injectAxe();
+  });
+
+  it("Check entire page for a11y issues", () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/e2e/homepage/dashboard.cy.ts
+++ b/cypress/e2e/homepage/dashboard.cy.ts
@@ -80,7 +80,7 @@ describe("Homepage dashboard", () => {
         name: "Find out more about collections",
       }).should("exist");
       cy.findByRole("link", {
-        name: "Collection a",
+        name: "Personal collection a",
       }).should("not.exist");
     });
 
@@ -142,7 +142,7 @@ describe("Homepage dashboard", () => {
         name: "Find out more about collections",
       }).should("not.exist");
       cy.findAllByRole("link", {
-        name: "Collection a",
+        name: "Personal collection a",
       }).should("exist");
     });
 

--- a/cypress/fixtures/collections.ts
+++ b/cypress/fixtures/collections.ts
@@ -1,0 +1,4 @@
+export const personalCollection = "616c6a6a-0e82-4a02-8e3b-9821eadb16bc";
+export const allUsersCollection = "83583644-36a5-4841-b62b-9df6dbbd5512";
+
+export type DataCatalogueIDType = typeof personalCollection;

--- a/dataworkspace/dataworkspace/templates/data_collections/request_access_to_collection_form.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/request_access_to_collection_form.html
@@ -31,20 +31,19 @@
       <span class="govuk-caption-xl govuk-!-margin-bottom-7">
       You need to request access from the owner of this collection.
     </span>
-      <p class="govuk-label govuk-!-font-weight-bold govuk-!-margin-bottom-3">Collection name</p>
+      <h2 class="govuk-heading-m">Collection name</h2>
       <p class="govuk-body govuk-!-margin-bottom-8">{{ collection.name }}</p>
-      <h2 class="govuk-label govuk-!-font-weight-bold govuk-!-margin-bottom-3">Collection owner</h2>
+      <h2 class="govuk-heading-m">Collection owner</h2>
       <p class="govuk-body govuk-!-margin-bottom-8">{{ collection.owner.get_full_name|default:'Not available' }}</p>
-
 
       <form method="post" novalidate>
         {% csrf_token %}
         <div class="govuk-form-group govuk-!-margin-bottom-7 {% if form.errors %}govuk-form-group--error{% endif %}">
-              <h1 class="govuk-label-wrapper">
-                <label class="govuk-label govuk-!-font-weight-bold govuk-!-margin-bottom-3" for="id_email">
+              <h2>
+                <label class="govuk-heading-m" for="id_email">
                   {{ form.email.label }}
                 </label>
-              </h1>
+              </h2>
                   <div class="govuk-hint">
             You are logged in as {{ request.user.email }}
           </div>

--- a/dataworkspace/dataworkspace/templates/data_collections/request_access_to_collection_form.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/request_access_to_collection_form.html
@@ -18,57 +18,53 @@
 {% block page_title %}
   {{ collection.name }}
 {% endblock %}
-{% block main %}
-    <div class="govuk-width-container">
-      <div class="govuk-breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-          <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-back-link" href="/">Back</a>
-          </li>
-        </ol>
-      </div>
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Request access to collection</h1>
-      <span class="govuk-caption-xl govuk-!-margin-bottom-7">
+
+{% block go_back %}
+  <a class="govuk-back-link" href="/">Back</a>
+{% endblock %}
+
+{% block content %}      
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Request access to collection</h1>
+    <span class="govuk-caption-xl govuk-!-margin-bottom-7">
       You need to request access from the owner of this collection.
     </span>
-      <h2 class="govuk-heading-m">Collection name</h2>
-      <p class="govuk-body govuk-!-margin-bottom-8">{{ collection.name }}</p>
-      <h2 class="govuk-heading-m">Collection owner</h2>
-      <p class="govuk-body govuk-!-margin-bottom-8">{{ collection.owner.get_full_name|default:'Not available' }}</p>
+    <h2 class="govuk-heading-m">Collection name</h2>
+    <p class="govuk-body govuk-!-margin-bottom-8">{{ collection.name }}</p>
+    <h2 class="govuk-heading-m">Collection owner</h2>
+    <p class="govuk-body govuk-!-margin-bottom-8">{{ collection.owner.get_full_name|default:'Not available' }}</p>
 
-      <form method="post" novalidate>
-        {% csrf_token %}
-        <div class="govuk-form-group govuk-!-margin-bottom-7 {% if form.errors %}govuk-form-group--error{% endif %}">
-              <h2>
-                <label class="govuk-heading-m" for="id_email">
-                  {{ form.email.label }}
-                </label>
-              </h2>
-                  <div class="govuk-hint">
-            You are logged in as {{ request.user.email }}
-          </div>
-              {% if form.errors %}
-                <span id="id_email-error" class="govuk-error-message">
-                  <span class="govuk-visually-hidden">Error: </span>{{ form.errors.0 }}
-                </span>
-              {% endif %}
-              {% if form.email.errors %}
-                <p class="govuk-error-message">
-                  {{ form.email.errors.0 }}
-                </p>
-              {% endif %}
-              <input
-                class="govuk-input govuk-!-width-two-thirds govuk-!-margin-bottom-7 {% if form.email.errors %} govuk-input--error{% endif %}"
-                type="email"
-                name="email"
-                id="id_email"
-                value="{{ form.email.value|default_if_none:request.user.email }}"
-              >
-          <div class="govuk-button-group">
-            <button type="submit" class="govuk-button">Continue</button>
-            <a class="govuk-link" href="/">Cancel</a>
-          </div>
+    <form method="post" novalidate>
+      {% csrf_token %}
+      <div class="govuk-form-group govuk-!-margin-bottom-7 {% if form.errors %}govuk-form-group--error{% endif %}">
+            <h2>
+              <label class="govuk-heading-m" for="id_email">
+                {{ form.email.label }}
+              </label>
+            </h2>
+                <div class="govuk-hint">
+          You are logged in as {{ request.user.email }}
         </div>
-      </form>
-    </div>
+            {% if form.errors %}
+              <span id="id_email-error" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error: </span>{{ form.errors.0 }}
+              </span>
+            {% endif %}
+            {% if form.email.errors %}
+              <p class="govuk-error-message">
+                {{ form.email.errors.0 }}
+              </p>
+            {% endif %}
+            <input
+              class="govuk-input govuk-!-width-two-thirds govuk-!-margin-bottom-7 {% if form.email.errors %} govuk-input--error{% endif %}"
+              type="email"
+              name="email"
+              id="id_email"
+              value="{{ form.email.value|default_if_none:request.user.email }}"
+            >
+        <div class="govuk-button-group">
+          <button type="submit" class="govuk-button">Continue</button>
+          <a class="govuk-link" href="/">Cancel</a>
+        </div>
+      </div>
+    </form>    
 {% endblock %}

--- a/dataworkspace/e2e_fixtures.json
+++ b/dataworkspace/e2e_fixtures.json
@@ -617,7 +617,7 @@
       "deleted": false,
       "created_by": 2,
       "updated_by": null,
-      "name": "Collection a",
+      "name": "Personal collection a",
       "description": "This is a collection description.",
       "owner": 2,
       "notes": null,
@@ -631,13 +631,13 @@
       "created_date": "2024-01-29T10:34:35.735Z",
       "modified_date": "2024-01-29T10:34:35.736Z",
       "deleted": false,
-      "created_by": 2,
+      "created_by": 1,
       "updated_by": null,
-      "name": "Collection b",
-      "description": "This is a collection description.",
-      "owner": 2,
+      "name": "Collection for all users",
+      "description": "This is a collection that is accessibile to all users of data workspace.",
+      "owner": 1,
       "notes": null,
-      "user_access_type": "REQUIRES_AUTHORIZATION"
+      "user_access_type": "REQUIRES_AUTHENTICATION"
     }
   },
   {
@@ -649,7 +649,7 @@
       "deleted": false,
       "created_by": 2,
       "updated_by": null,
-      "name": "Collection c",
+      "name": "Personal collection b",
       "description": "This is a collection description.",
       "owner": 2,
       "notes": null,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "debug:css": "node-sass dataworkspace/dataworkspace/sass --output dataworkspace/dataworkspace/static/css --source-map true --source-map-contents --include-path node_modules",
     "preinstall": "npx npm-force-resolutions",
     "cypress:run": "cypress run",
-    "cypress:open": "cypress open"
+    "cypress:run:a11y": "cypress run --config-file cypress.a11y.config.ts",
+    "cypress:open": "cypress open",
+    "cypress:open:a11y": "cypress open --config-file cypress.a11y.config.ts"
   },
   "resolutions": {
     "scss-tokenizer": "0.4.3"


### PR DESCRIPTION
### Description of change
- Use a common h2 html element for the form fields
- Fixed issue where the  request_access_to_collection_form.html file was overriding the `main` block instead of the `content` block from the `_main.html` template. This was causing axe errors with a missing `<main>` tag
- Updated e2e test data to make collection titles more detailed as to what they represent

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [x] Have Accessibility tests been added to cover any React changes?