### PR TITLE
chore/use-latest-circle-node-image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   docker-test-unit-js:
     docker:
-      - image: circleci/node:16
+      - image: cimg/node:16.20
     steps:
       - checkout
       - run:


### PR DESCRIPTION
### Description of change
The circle image for node being used has been deprecated, switch to the latest. for more info: https://circleci.com/developer/images/image/cimg/node
### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?