### PR TITLE
Reset view button resets boolean type column filters

### DIFF
--- a/cypress/e2e/data-catalogue/data-grid.cy.ts
+++ b/cypress/e2e/data-catalogue/data-grid.cy.ts
@@ -1,0 +1,53 @@
+import { sourceWithTable } from "../../fixtures/datasets";
+
+const dataUrl = "**/data?count=1";
+
+const checkRequestBody = (alias: string, expected: string) => {
+  cy.wait(alias)
+    .its("request.body")
+    .then((body) => JSON.stringify(body))
+    .should("include", expected);
+};
+
+describe("Data grid filters", () => {
+  context("When filtering a boolean column", () => {
+    it("should clear the filter when reset view is clicked", () => {
+      cy.visit(`/datasets/${sourceWithTable}`);
+
+      cy.intercept("POST", dataUrl, {
+        statusCode: 200,
+        body: {
+          rowcount: {
+            count: 3,
+          },
+          download_limit: 100,
+          records: [
+            {
+              id: 1,
+              data: true,
+            },
+            {
+              id: 2,
+              data: false,
+            },
+            {
+              id: 3,
+              data: true,
+            },
+          ],
+        },
+      }).as("getData");
+      cy.get("a").contains("source_data_set").click();
+      checkRequestBody("@getData", '"filters":{}');
+      cy.get("span.ag-icon.ag-icon-menu").last().click();
+
+      cy.intercept("POST", dataUrl).as("filteredData");
+      cy.get('input[aria-label="Filter Value"]').type("true");
+      checkRequestBody("@filteredData", '"filter":"true"');
+
+      cy.intercept("POST", dataUrl).as("resetData");
+      cy.get("button").contains("Reset view").click();
+      checkRequestBody("@resetData", '"filters":{}');
+    });
+  });
+});

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -512,6 +512,20 @@ function initDataGrid(
     .addEventListener("click", function (e) {
       gridOptions.api.setFilterModel(null);
       gridOptions.columnApi.resetColumnState();
+
+      // Unset filters for any boolean type columns
+      const booleanFilterColumns = gridOptions.api.getColumnDefs().filter(
+        (column) => column.filter.name === "NewBooleanFilterComponent"
+      );
+      booleanFilterColumns.forEach((column) => {
+        const filter = gridOptions.api.getFilterInstance(
+          column.field
+        );
+        if (filter) {
+          filter.clearFilter();
+        }
+      });
+
       // Unset the saved column config
       gridOptions.columnApi.getColumns().forEach((c) => {
         gridOptions.columnApi.setColumnVisible(c.getColId(), true);


### PR DESCRIPTION
### Description of change
When setting a filter on a dataset that is of type boolean, the reset view button should now clear the filter.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?