### PR TITLE
a11y: Add aria-label to highlight how to remove a filter

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/partials/filter_button.html
+++ b/dataworkspace/dataworkspace/templates/datasets/partials/filter_button.html
@@ -1,4 +1,9 @@
-<button data-id="{{ id }}" data-module="remove-filter" data-filter-type="{{ tag_type }}"
-        class="filter-button">&#x2716;&nbsp;{% if label %}{{ label }}: {% endif %}{{ text }}
+<button
+  data-id="{{ id }}"
+  data-module="remove-filter"
+  data-filter-type="{{ tag_type }}"
+  class="filter-button"
+  aria-label="Remove filter {% if label %}{{ label }}: {% endif %}{{ text }}"
+>
+  &#x2716;&nbsp;{% if label %}{{ label }}: {% endif %}{{ text }}
 </button>
-


### PR DESCRIPTION
### Description of change
Add aria-label to filter label so screen readers / users who cannot see the 'x' on a filter can know how to remove a filter.

![Screenshot 2024-03-20 at 10 48 06](https://github.com/uktrade/data-workspace-frontend/assets/54268863/cd524e0b-1c72-4cf6-bcae-7e93769e199c)

#### Example with aria-label:
```
<button data-id="1" data-module="remove-filter" data-filter-type="data_type" class="filter-button" aria-label="Remove filter Type: Source dataset">
  ✖&nbsp;Type: Source dataset
</button>
```

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?