### PR TITLE
feat: remove some of the locking when granting to a role

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -210,19 +210,14 @@ def new_private_database_credentials(
             missing_db_roles = [role for (role,) in cur.fetchall()]
 
         if missing_db_roles:
-            with cache.lock(
-                "database-grant-v1",
-                blocking_timeout=15,
-                timeout=60,
-            ), connections[database_memorable_name].cursor() as cur:
-                cur.execute(
-                    sql.SQL("GRANT {} TO {};").format(
-                        sql.SQL(",").join(
-                            sql.Identifier(missing_db_role) for missing_db_role in missing_db_roles
-                        ),
-                        sql.Identifier(database_data["USER"]),
-                    )
+            cur.execute(
+                sql.SQL("GRANT {} TO {};").format(
+                    sql.SQL(",").join(
+                        sql.Identifier(missing_db_role) for missing_db_role in missing_db_roles
+                    ),
+                    sql.Identifier(database_data["USER"]),
                 )
+            )
 
         if switch_is_active(settings.CACHE_USER_TABLE_PERMISSIONS):
             logging.info("Caching switch is active. Trying to get cached table permissions")


### PR DESCRIPTION
### Description of change

This removes what is thought to be unnecessary locking - although we do need locking when GRANTing SELECT to a table, because the permissions are all stored in one field in pg_class, GRANTing a role to another role is done by adding a row to pg_auth_members, which shouldn't need locking.

This is done as a small step towards hopefully more robust tools launches - while this change might look like it decreases robustness, locking adds to slowness, and if it turns out we _do_ need this locking, we need to known now, as we're about to build on the pattern that assumes that changes to role membership doesn't need locking.

There are existing integration tests that cover at least the main parts of tools being granted enough permissions to access datasets. While not impossible to make a test that asserts that the locking removed here is indeed unnecessary, think it will take quite a long time and become not worth it.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?