### PR TITLE
fix: cursor already closed error when granting db permissions error

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -209,15 +209,15 @@ def new_private_database_credentials(
             )
             missing_db_roles = [role for (role,) in cur.fetchall()]
 
-        if missing_db_roles:
-            cur.execute(
-                sql.SQL("GRANT {} TO {};").format(
-                    sql.SQL(",").join(
-                        sql.Identifier(missing_db_role) for missing_db_role in missing_db_roles
-                    ),
-                    sql.Identifier(database_data["USER"]),
+            if missing_db_roles:
+                cur.execute(
+                    sql.SQL("GRANT {} TO {};").format(
+                        sql.SQL(",").join(
+                            sql.Identifier(missing_db_role) for missing_db_role in missing_db_roles
+                        ),
+                        sql.Identifier(database_data["USER"]),
+                    )
                 )
-            )
 
         if switch_is_active(settings.CACHE_USER_TABLE_PERMISSIONS):
             logging.info("Caching switch is active. Trying to get cached table permissions")


### PR DESCRIPTION
### Description of change

This fixes an error introduced in
https://github.com/uktrade/data-workspace-frontend/pull/3108/files - when granting missing roles to the master user it attempted to use a closed cursor, i.e. outside the context manager in which it's open.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?