### PR TITLE
A11y: Add aria-label to tools notification

### DIFF
--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -93,7 +93,7 @@
               </li>
               {% with tools_count=RUNNING_TOOLS.count %}
                 <li class="govuk-header__navigation-item{% if request.get_full_path == tools_url %} govuk-header__navigation-item--active{% endif %}">
-                  <a class="govuk-header__link" href="{{ tools_url }}">Tools</a>
+                  <a class="govuk-header__link" {% if tools_count > 0 %}aria-label="You have {{ tools_count }} tool{{ tools_count | pluralize }} running"{% endif %} href="{{ tools_url }}">Tools</a>
                   {% if tools_count > 0 %}<span class="badge">{{ tools_count }}</span>{% endif %}
 
                 </li>


### PR DESCRIPTION
### Description of change
When using a screen reader, the number of active tools should be read out. The example below would say:  "You have 3 tools running"
![Screenshot 2024-03-22 at 12 08 55](https://github.com/uktrade/data-workspace-frontend/assets/54268863/00e357f6-be90-4c28-9b00-3bb19c671ff5)

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?