### PR TITLE
feat: filter out dit schemas from views and permissions

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -650,7 +650,7 @@ def can_access_schema_table(user, database, schema, table):
         .exists()
     )
 
-    return has_source_table_perms
+    return schema != "dit" and has_source_table_perms
 
 
 def get_team_schemas_for_user(user):
@@ -777,7 +777,9 @@ def source_tables_for_user(user):
         .exclude(external_database=None)
         .values("external_database__memorable_name", "table_name", "uuid", "name")
     ]
-    return source_tables + reference_dataset_tables
+    return [
+        table for table in (source_tables + reference_dataset_tables) if table["schema"] != "dit"
+    ]
 
 
 def source_tables_for_app(application_template):
@@ -825,7 +827,9 @@ def source_tables_for_app(application_template):
         .filter(published=True, deleted=False)
         .exclude(external_database=None)
     ]
-    return source_tables + reference_dataset_tables
+    return [
+        table for table in (source_tables + reference_dataset_tables) if table["schema"] != "dit"
+    ]
 
 
 def view_exists(database, schema, view):

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -433,6 +433,9 @@ class DatasetDetailView(DetailView):
 
     def _get_context_data_for_master_dataset(self, ctx, **kwargs):
         source_tables = sorted(self.object.sourcetable_set.all(), key=lambda x: x.name)
+        source_tables = [
+            source_table for source_table in source_tables if source_table.schema != "dit"
+        ]
 
         MasterDatasetInfo = namedtuple(
             "MasterDatasetInfo",


### PR DESCRIPTION
### Description of change

This is a bit of a workaround because it's a touch more complex than thought to have non-published source tables (without destroying their historical log info)

Hopefully this will be followed by some sort of unpublish/soft delete for source tables.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?