### PR TITLE
feat: update content for nav links for managing visualisations

### DIFF
--- a/dataworkspace/dataworkspace/templates/_visualisation.html
+++ b/dataworkspace/dataworkspace/templates/_visualisation.html
@@ -5,8 +5,8 @@
 {% block page_title %}Visualisations - {{ block.super }}{% endblock %}
 
 {% block head %}
-  {{ block.super }}
-  <style>
+{{ block.super }}
+<style>
     .branch-icon-small {
         display: inline-block;
         height: 16px;
@@ -14,6 +14,7 @@
         position: relative;
         top: 2px;
     }
+
     .branch-icon-large {
         display: inline-block;
         height: 24px;
@@ -21,147 +22,179 @@
         position: relative;
         top: 2px;
     }
+
     @media (min-width: 40.0625em) {
         .branch-icon-large {
             height: 30px;
             width: 30px;
         }
     }
+
     .nav {
         margin-left: 14px;
     }
+
     @media (min-width: 40.0625em) {
         .nav {
             margin-left: 0;
         }
     }
+
     .nav-item--current {
         margin-left: -14px;
         padding-left: 10px;
         border-left: 4px solid #1d70b8;
     }
+
     .subnav-item {
         /* Only makes a difference for long branch names that wrap to the next line */
         text-indent: -19px;
         padding-left: 19px;
     }
+
     .nav-item-link:link,
     .subnav-item-link:link {
         text-decoration: none;
     }
+
     .nav-item-link--current,
     .subnav-item-link--current {
         font-weight: bold;
     }
-    .underline-on-hover--parent:hover > .underline-on-hover {
+
+    .underline-on-hover--parent:hover>.underline-on-hover {
         text-decoration: underline;
     }
-    .underline-on-hover--parent:active > .underline-on-hover,
-    .underline-on-hover--parent:focus > .underline-on-hover {
+
+    .underline-on-hover--parent:active>.underline-on-hover,
+    .underline-on-hover--parent:focus>.underline-on-hover {
         text-decoration: none;
     }
+
     .commit,
     .production {
         background: #f3f2f1;
         border: 1px solid #b1b4b6;
     }
+
     @media (min-width: 40.0625em) {
+
         /* If a browser doesn't support flexbox, the elements will just
            be stacked, similar to mobile view */
         .commit-row {
             display: flex;
             flex-wrap: wrap;
         }
+
         .commit-left {
             flex-grow: 1;
             padding-right: 20px;
         }
+
         .commit-right {
             text-align: center;
         }
     }
+
     .visualisation-user-email {
         display: block;
         font-weight: normal;
     }
+
     .visualisation-dataset__item {
         border-bottom: 1px solid #b1b4b6;
     }
+
     .visualisation-dataset__label {
         padding-top: 0;
         padding-bottom: 0;
         font-weight: bold;
     }
+
     /* The default GDS styles the labels of disable elements as grey using
        opacity. However, this looks a bit _too_ disabled in the case of
        selected but disabled items. So we override to only disable the
        checkbox, which is made of the :before and :after pseudo elements of
        the label */
-    .govuk-checkboxes__input:disabled + .visualisation-dataset__label {
+    .govuk-checkboxes__input:disabled+.visualisation-dataset__label {
         opacity: 1.0;
     }
-    .govuk-checkboxes__input:disabled + .visualisation-dataset__label:before,
-    .govuk-checkboxes__input:disabled + .visualisation-dataset__label:after {
+
+    .govuk-checkboxes__input:disabled+.visualisation-dataset__label:before,
+    .govuk-checkboxes__input:disabled+.visualisation-dataset__label:after {
         opacity: 0.5;
     }
+
     .list-item-with-prefix::before {
         content: "—";
         font-weight: normal;
     }
-  </style>
+</style>
 {% endblock %}
 
 {% block breadcrumbs %}
-    <div class="govuk-breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" href="/">Home</a>
-            </li>
+<div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+        <li class="govuk-breadcrumbs__list-item">
+            <a class="govuk-breadcrumbs__link" href="/">Home</a>
+        </li>
 
-            <li class="govuk-breadcrumbs__list-item">
-               <a class="govuk-breadcrumbs__link" href="{% url 'visualisations:root' %}">Visualisations</a>
-            </li>
+        <li class="govuk-breadcrumbs__list-item">
+            <a class="govuk-breadcrumbs__link" href="{% url 'visualisations:root' %}">Visualisations</a>
+        </li>
 
-            <li class="govuk-breadcrumbs__list-item">
-                {{ gitlab_project.name }}
-            </li>
+        <li class="govuk-breadcrumbs__list-item">
+            {{ gitlab_project.name }}
+        </li>
 
-            <!-- The lack of the name of the specific page under the visualisation name here is
+        <!-- The lack of the name of the specific page under the visualisation name here is
                  deliberate. It is clear from multiple other elements -->
-        </ol>
-    </div>
+    </ol>
+</div>
 {% endblock %}
 
 {% block nav %}
 <ul class="govuk-list nav govuk-!-font-size-18 govuk-!-margin-bottom-8">
     <li class="nav-item{% if current_menu_item == 'branches' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
-        <a href="{% url 'visualisations:branch' gitlab_project.id gitlab_project.default_branch %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'branches' %} nav-item-link--current{% endif %} underline-on-hover--parent">
-            <span class="underline-on-hover">Branches</span>
+        <a href="{% url 'visualisations:branch' gitlab_project.id gitlab_project.default_branch %}"
+            class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'branches' %} nav-item-link--current{% endif %} underline-on-hover--parent">
+            Preview
         </a>
         <ul class="govuk-list subnav govuk-!-font-size-16">
             {% for branch in branches %}
             <li class="subnav-item">
-                <a href="{% url 'visualisations:branch' gitlab_project.id branch.name %}" class="govuk-link govuk-link--no-visited-state subnav-item-link {% if current_branch.name == branch.name %}subnav-item-link--current{% endif %} underline-on-hover--parent">
-                    <svg class="branch-icon-small" focusable="false" data-prefix="fas" data-icon="code-branch" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><title>Branch</title><path fill="currentColor" d="M384 144c0-44.2-35.8-80-80-80s-80 35.8-80 80c0 36.4 24.3 67.1 57.5 76.8-.6 16.1-4.2 28.5-11 36.9-15.4 19.2-49.3 22.4-85.2 25.7-28.2 2.6-57.4 5.4-81.3 16.9v-144c32.5-10.2 56-40.5 56-76.3 0-44.2-35.8-80-80-80S0 35.8 0 80c0 35.8 23.5 66.1 56 76.3v199.3C23.5 365.9 0 396.2 0 432c0 44.2 35.8 80 80 80s80-35.8 80-80c0-34-21.2-63.1-51.2-74.6 3.1-5.2 7.8-9.8 14.9-13.4 16.2-8.2 40.4-10.4 66.1-12.8 42.2-3.9 90-8.4 118.2-43.4 14-17.4 21.1-39.8 21.6-67.9 31.6-10.8 54.4-40.7 54.4-75.9zM80 64c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16zm0 384c-8.8 0-16-7.2-16-16s7.2-16 16-16 16 7.2 16 16-7.2 16-16 16zm224-320c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16z"></path></svg> <span class="underline-on-hover">{{ branch.name }}</span>
+                <a href="{% url 'visualisations:branch' gitlab_project.id branch.name %}"
+                    class="govuk-link govuk-link--no-visited-state subnav-item-link {% if current_branch.name == branch.name %}subnav-item-link--current{% endif %} underline-on-hover--parent">
+                    <svg class="branch-icon-small" focusable="false" data-prefix="fas" data-icon="code-branch"
+                        role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+                        <title>Branch</title>
+                        <path fill="currentColor"
+                            d="M384 144c0-44.2-35.8-80-80-80s-80 35.8-80 80c0 36.4 24.3 67.1 57.5 76.8-.6 16.1-4.2 28.5-11 36.9-15.4 19.2-49.3 22.4-85.2 25.7-28.2 2.6-57.4 5.4-81.3 16.9v-144c32.5-10.2 56-40.5 56-76.3 0-44.2-35.8-80-80-80S0 35.8 0 80c0 35.8 23.5 66.1 56 76.3v199.3C23.5 365.9 0 396.2 0 432c0 44.2 35.8 80 80 80s80-35.8 80-80c0-34-21.2-63.1-51.2-74.6 3.1-5.2 7.8-9.8 14.9-13.4 16.2-8.2 40.4-10.4 66.1-12.8 42.2-3.9 90-8.4 118.2-43.4 14-17.4 21.1-39.8 21.6-67.9 31.6-10.8 54.4-40.7 54.4-75.9zM80 64c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16zm0 384c-8.8 0-16-7.2-16-16s7.2-16 16-16 16 7.2 16 16-7.2 16-16 16zm224-320c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16z">
+                        </path>
+                    </svg> <span class="underline-on-hover">{{ branch.name }}</span>
                 </a>
             </li>
             {% endfor %}
         </ul>
     </li>
     {% if show_users_section %}
-    <li class="nav-item{% if current_menu_item == 'users-give-access' or current_menu_item == 'users-with-access' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
-        <a href="{% url 'visualisations:users-give-access' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'users-give-access' or current_menu_item == 'users-with-access' %} nav-item-link--current{% endif %}">
-            Users
+    <li
+        class="nav-item{% if current_menu_item == 'users-give-access' or current_menu_item == 'users-with-access' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
+        <a href="{% url 'visualisations:users-give-access' gitlab_project.id %}"
+            class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'users-give-access' or current_menu_item == 'users-with-access' %} nav-item-link--current{% endif %}">
+            Manage access
         </a>
 
         <ul class="govuk-list subnav govuk-!-font-size-16">
             <li class="subnav-item">
-                <a href="{% url 'visualisations:users-give-access' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state subnav-item-link list-item-with-prefix{% if current_menu_item == 'users-give-access' %} subnav-item-link--current{% endif %}">
+                <a href="{% url 'visualisations:users-give-access' gitlab_project.id %}"
+                    class="govuk-link govuk-link--no-visited-state subnav-item-link list-item-with-prefix{% if current_menu_item == 'users-give-access' %} subnav-item-link--current{% endif %}">
                     Give access
                 </a>
             </li>
             <li class="subnav-item">
-                <a href="{% url 'visualisations:users-with-access' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state subnav-item-link list-item-with-prefix{% if current_menu_item == 'users-with-access' %} subnav-item-link--current{% endif %}">
+                <a href="{% url 'visualisations:users-with-access' gitlab_project.id %}"
+                    class="govuk-link govuk-link--no-visited-state subnav-item-link list-item-with-prefix{% if current_menu_item == 'users-with-access' %} subnav-item-link--current{% endif %}">
                     With access
                 </a>
             </li>
@@ -169,22 +202,27 @@
     </li>
     {% endif %}
     <li class="nav-item{% if current_menu_item == 'datasets' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
-        <a href="{% url 'visualisations:datasets' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'datasets' %} nav-item-link--current{% endif %}">
-            Datasets
+        <a href="{% url 'visualisations:datasets' gitlab_project.id %}"
+            class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'datasets' %} nav-item-link--current{% endif %}">
+            Datasets used
         </a>
     </li>
-    <li class="nav-item{% if current_menu_item == 'catalogue-item' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
-        <a href="{% url 'visualisations:catalogue-item' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'catalogue-item' %} nav-item-link--current{% endif %}">
-            Catalogue item
+    <li
+        class="nav-item{% if current_menu_item == 'catalogue-item' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
+        <a href="{% url 'visualisations:catalogue-item' gitlab_project.id %}"
+            class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'catalogue-item' %} nav-item-link--current{% endif %}">
+            Metadata
         </a>
     </li>
     <li class="nav-item{% if current_menu_item == 'approvals' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
-        <a href="{% url 'visualisations:approvals' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'approvals' %} nav-item-link--current{% endif %}">
+        <a href="{% url 'visualisations:approvals' gitlab_project.id %}"
+            class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'approvals' %} nav-item-link--current{% endif %}">
             Approvals
         </a>
     </li>
     <li class="nav-item{% if current_menu_item == 'publish' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
-        <a href="{% url 'visualisations:publish' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'publish' %} nav-item-link--current{% endif %}">
+        <a href="{% url 'visualisations:publish' gitlab_project.id %}"
+            class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'publish' %} nav-item-link--current{% endif %}">
             Publish
         </a>
     </li>


### PR DESCRIPTION
### Description of change
This change proposes content updates to the links down the left hand side of the page for managing visualisations.

### How to test
1. Visit `/visualisations/`
2. Click on "Manage"
3. View the links down the left hand side.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?