### PR TITLE
refactor: slightly simplier query fetching existing schema perms

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -281,9 +281,7 @@ def new_private_database_credentials(
                 FROM
                     pg_namespace, aclexplode(nspacl)
                 WHERE
-                    nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast', {schema})
-                    AND nspname NOT LIKE 'pg_temp_%'
-                    AND nspname NOT LIKE 'pg_toast_temp_%'
+                    nspname != {schema}
                     AND grantee = {role}::regrole
                     AND privilege_type IN ('CREATE', 'USAGE')
                 ORDER BY nspname;


### PR DESCRIPTION
### Description of change

Because we now check permissions directly on pg_namespace, we don't need to exclude information_schema or pg_* schemas because users are never granted permissions on them directly.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?