### PR TITLE
fix: don't swallow exceptions when locking in grant credentials flow

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -124,6 +124,7 @@ def transaction_and_lock(cursor, lock_id):
         yield
     except Exception:  # pylint: disable=broad-except
         cursor.execute(sql.SQL("ROLLBACK"))
+        raise
     else:
         cursor.execute(sql.SQL("COMMIT"))
 


### PR DESCRIPTION
### Description of change

This fixes an issue where there can be errors when creating tools credentials, but they would be hidden.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?