### PR TITLE
fix: avoid premature quoting of schema name when finding existing tables

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -263,8 +263,9 @@ def new_private_database_credentials(
             cur.execute(
                 sql.SQL(
                     """
-                SELECT relnamespace::regnamespace::text AS table_schema, relname AS table_name
-                FROM pg_class WHERE relkind IN ('r', 'm', 'v', 'p');
+                SELECT nspname AS table_schema, relname AS table_name
+                FROM pg_class WHERE relkind IN ('r', 'm', 'v', 'p')
+                INNER JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace;
             """
                 )
             )
@@ -1783,14 +1784,16 @@ def table_permissions_for_role(db_role, db_schema, database_name, log_stats=Fals
         return tables_with_perms
 
     pg_class_query = """
-        SELECT relnamespace::regnamespace::text AS schema, relname AS name
-        FROM pg_class, aclexplode(relacl) acl
+        SELECT nspname AS schema, relname AS name
+        FROM pg_class
+        INNER JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+        CROSS JOIN aclexplode(relacl) acl
         WHERE acl.grantee = {role}::regrole::oid
         AND relkind in ('r', 'p')
         AND acl.privilege_type in (
             'SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'
         )
-        AND relnamespace::regnamespace::text NOT SIMILAR TO
+        AND nspname NOT SIMILAR TO
             'pg_toast|pg_temp_%|pg_toast_temp_%|_team_%|_user_%'
         AND relname NOT SIMILAR TO
             '_\\d{{8}}t\\d{{6}}|%_swap|%_idx|_tmp%|%_pkey|%_seq|_data_explorer_tmp%|%000000|_tmp_%';


### PR DESCRIPTION
### Description of change

Using the magical ::regnamespace casting returns the schema names already quoted, which then in later code assumes are really part of the names. This then causes errors since the schemas don't actually exist.

Joingin on pg_namespace avoids this.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?