### PR TITLE
fix: clear cache for app user when it is saved from the vis manage page

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -1859,6 +1859,10 @@ def clear_table_permissions_cache_for_user(user):
         user.email,
         db_role,
     )
+    delete_cache_for_db_role(db_role)
+
+
+def delete_cache_for_db_role(db_role):
     cache.delete(table_permissions_cache_key(db_role))
 
 


### PR DESCRIPTION
### Description of change

Bust the db role permissions cache when a user made a change to the datasets in a visualisation.  

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?