### PR TITLE
Changing the qs limit to 50, keeping other tools at 10

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -630,8 +630,9 @@ def new_private_database_credentials(
                     )
                 )
                 cur.execute(
-                    sql.SQL("ALTER USER {} WITH CONNECTION LIMIT 10;").format(
+                    sql.SQL("ALTER USER {} WITH CONNECTION LIMIT {};").format(
                         sql.Identifier(_db_user),
+                        sql.Literal(50 if db_user.endswith("_qs") else 10),
                     )
                 )
 


### PR DESCRIPTION
### Description of change

Quicksight users were getting an error where there were too many connections, so increase the limit for them. Keeping the limit for general tool users low, as people can accidentally make thousands of connections and use all the connections available in the database. However, this is much harder to do in Quicksight.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?