### PR TITLE
feat: increase statement timeout when creating credentials

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -111,7 +111,7 @@ def db_role_schema_suffix_for_app(application_template):
 @contextmanager
 def get_cursor(database_memorable_name):
     with connections[database_memorable_name].cursor() as cursor:
-        cursor.execute(sql.SQL("SET statement_timeout = '30s'"))
+        cursor.execute(sql.SQL("SET statement_timeout = '120s'"))
         yield cursor
 
 


### PR DESCRIPTION
### Description of change

Especially when the database is under load, querying permissions on pg_class is taking quite a while and causing tools to fail to load. We are manually clearing up pg_class permissions separately, which should help, but to see if can get tools working now, the best thing that can think of is to increase the timeout.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?