### PR TITLE
perf: slightly faster checking for existing tables

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -1202,26 +1202,16 @@ def tables_and_views_that_exist(cur, schema_tables):
         sql.SQL(
             """
         SELECT
-            schemaname AS schema, tablename AS name
+            nspname AS schema, relname AS name
         FROM
-            pg_catalog.pg_tables
-        WHERE (
-            (schemaname, tablename) IN ({existing})
-        )
-        UNION
-        SELECT
-            schemaname AS schema, viewname AS name
-        FROM
-            pg_catalog.pg_views
+            pg_class
+        INNER JOIN
+            pg_namespace ON pg_namespace.oid = pg_class.relnamespace
         WHERE
-            (schemaname, viewname) IN ({existing})
-        UNION
-        SELECT
-            schemaname AS schema, matviewname AS name
-        FROM
-            pg_catalog.pg_matviews
-        WHERE
-             (schemaname, matviewname) IN ({existing})
+            relkind in ('r', 'm', 'v', 'p')
+            AND (nspname, relname) IN ({existing})
+        ORDER BY
+            nspname, relname
     """
         ).format(
             existing=sql.SQL(",").join(


### PR DESCRIPTION
### Description of change

This should make it just a touch faster to query for existing tables when syncing permissions.

The previous version would be slower for 2 reasons:

- Querying views that each do more than they need to for our purposes.
- And the fact 3 views were queried, when 1 query on pg_class is all that's needed.

This is done because according to RDS performance insights, the previous query had an every latency of ~30 seconds, which is far far too much for something that should be really cheap.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?