### PR TITLE
fix: don't try to revoke an app's own role when loading

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -322,6 +322,7 @@ def new_private_database_credentials(
                         rolname LIKE '\\_team\\_%'
                         OR rolname LIKE '\\_user\\_app\\_%'
                     )
+                    AND rolname != {db_role} -- If loading an app, don't include its own role
                     AND pg_has_role({db_role}, rolname, 'member');
             """
                 ).format(db_role=sql.Literal(db_role))


### PR DESCRIPTION
### Description of change

This stops REVOKE of an app's own role when loading it by not including it in the list of any "shared" roles it may have.

(Realistically an app will not have any access granted to shared roles, unless it was done manually somehow. This code is more for human user's roles that are granted team membership.)

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?