### PR TITLE
fix: ensure can grant and revoke shared roles

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -794,6 +794,16 @@ def new_private_database_credentials(
                     )
                 )
 
+            # The master user has to be a member of the user's role for the ALTER DEFAULT PRIVILEGES
+            # changes below
+            if db_shared_roles_to_revoke or db_shared_roles_to_grant:
+                cur.execute(
+                    sql.SQL("GRANT {} TO {}").format(
+                        sql.Identifier(db_role),
+                        sql.Identifier(database_data["USER"]),
+                    )
+                )
+
             logger.info(
                 "Revoking %s from %s",
                 db_shared_roles_to_revoke,
@@ -861,6 +871,14 @@ def new_private_database_credentials(
                             sql.Identifier(db_shared_role),
                         )
                     )
+
+            if db_shared_roles_to_revoke or db_shared_roles_to_grant:
+                cur.execute(
+                    sql.SQL("REVOKE {} FROM {}").format(
+                        sql.Identifier(db_role),
+                        sql.Identifier(database_data["USER"]),
+                    )
+                )
 
         # Make it so by default, objects created by the user are owned by the role
         with get_cursor(database_memorable_name) as cur:


### PR DESCRIPTION
### Description of change

The recent changes where the master user doesn't have the user's roles granted. However, it looks like to grant/revoke various things, the master user has to be a member of the user's role. This change does that.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?