### PR TITLE
Fix the select dropdown in admin

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -906,7 +906,11 @@ class VisualisationCatalogueItemAdmin(CSPRichTextEditorMixin, DeletableTimeStamp
     inlines = [VisualisationLinkInline]
 
     class Media:
-        js = ("js/min/django_better_admin_arrayfield.min.js", "admin/js/jquery.init.js", "data-workspace-admin.js")
+        js = (
+            "js/min/django_better_admin_arrayfield.min.js",
+            "admin/js/jquery.init.js",
+            "data-workspace-admin.js",
+        )
         css = {
             "all": (
                 "css/min/django_better_admin_arrayfield.min.css",

--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -906,7 +906,7 @@ class VisualisationCatalogueItemAdmin(CSPRichTextEditorMixin, DeletableTimeStamp
     inlines = [VisualisationLinkInline]
 
     class Media:
-        js = ("js/min/django_better_admin_arrayfield.min.js", "data-workspace-admin.js")
+        js = ("js/min/django_better_admin_arrayfield.min.js", "admin/js/jquery.init.js", "data-workspace-admin.js")
         css = {
             "all": (
                 "css/min/django_better_admin_arrayfield.min.css",


### PR DESCRIPTION
### Description of change

When we released #3141 we forgot to update the JS in the admin area for visualisation catalogue items. As a result jQuery was undefined causing the select drop downs to fail in admin. This change enable the jQuery object to be initialised before we need to call it.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?