### PR TITLE
fix/ DT-1921 update css class name for type and name on upload modal

### DIFF
--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
@@ -32,8 +32,8 @@ function UploadHeaderRow() {
 function UploadFileRow(props) {
   return (
     <tr className="govuk-table__row">
-      <td className="govuk-table__cell">{props.file.relativePath}</td>
-      <td className="govuk-table__cell">{props.file.type}</td>
+      <td className="govuk-table__cell--word-wrapper">{props.file.relativePath}</td>
+      <td className="govuk-table__cell--word-wrapper">{props.file.type}</td>
       <td className="govuk-table__cell govuk-table__cell--numeric">
         {bytesToSize(props.file.size)}
       </td>

--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
@@ -32,8 +32,8 @@ function UploadHeaderRow() {
 function UploadFileRow(props) {
   return (
     <tr className="govuk-table__row">
-      <td className="govuk-table__cell--word-wrapper">{props.file.relativePath}</td>
-      <td className="govuk-table__cell--word-wrapper">{props.file.type}</td>
+      <td className="govuk-table__cell govuk-table__cell--word-wrapper">{props.file.relativePath}</td>
+      <td className="govuk-table__cell govuk-table__cell--word-wrapper">{props.file.type}</td>
       <td className="govuk-table__cell govuk-table__cell--numeric">
         {bytesToSize(props.file.size)}
       </td>


### PR DESCRIPTION
### Description of change
This PR is to wrap one line file name and type when user is uploading a file on their folder.
### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?