### PR TITLE
Allow scrollable table when uploading more than 5 files

### DIFF
--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
@@ -380,3 +380,31 @@
     box-shadow: 0 0 0 5px #ffbf47;
   }
 }
+
+.upload-files__table-container{
+  max-height: 275px;
+  overflow: scroll;
+  margin-bottom: 10px;
+  table {
+ border-collapse: separate;
+   position: relative;
+    th {
+      position: sticky;
+        top: 0;
+        background-color: white;
+    }
+  }
+}
+
+.upload-files__table-container::-webkit-scrollbar {
+    -webkit-appearance: none;
+}
+
+.upload-files__table-container::-webkit-scrollbar:vertical{
+    width: 10px;
+  }
+.upload-files__table-container::-webkit-scrollbar-thumb {
+    border-radius: 8px;
+    border: 2px solid white;
+    background-color: rgba(0, 0, 0, .5);
+}

--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
@@ -206,7 +206,7 @@ export class UploadFilesPopup extends React.Component {
               <div className="modal-contents">
                 <div className="modal-body">
                   <div className="col-md-18">
-                    <div className="panel-body">
+                    <div className="panel-body upload-files__table-container">
                       <table
                         className="govuk-table"
                         style={{ tableLayout: 'fixed' }}


### PR DESCRIPTION
### Description of change

Ticket [DT-1920](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-1920)

Currently the buttons are covering the files listed in the table if the user has chosen more than 5 files to upload.

![Screenshot 2024-04-16 at 14 02 17](https://github.com/uktrade/data-workspace-frontend/assets/10154302/6f0f895b-34fb-4929-a6ed-b391a244a2bc)

This change now limits the table to show a maximum of 5 files, anymore than 5 then the user has to scroll.

### How to test
1. Go to "Your files" by visiting `/files`
2. Try uploading more than 5 files
3. You should only 5 in the table and the table should now be scrollable

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?

[DT-1920]: https://uktrade.atlassian.net/browse/DT-1920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ