### PR TITLE
feat/DT-1913: Add upload location message to upload files modal

### DIFF
--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
@@ -14,7 +14,7 @@ function HeaderMessage() {
         automatically to the bigdata folder. The upload location is in the table
         below.{' '}
         <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/your-files/uploading-files-to-your-files/">
-          Find out more about storing files in Your Files
+          Find out more about storing files in Your Files.
         </a>
       </strong>
     </p>
@@ -47,8 +47,12 @@ function UploadHeaderRow() {
 function UploadFileRow(props) {
   return (
     <tr className="govuk-table__row">
-      <td className="govuk-table__cell govuk-table__cell--word-wrapper">{props.file.relativePath}</td>
-      <td className="govuk-table__cell govuk-table__cell--word-wrapper">{props.file.type}</td>
+      <td className="govuk-table__cell govuk-table__cell--word-wrapper">
+        {props.file.relativePath}
+      </td>
+      <td className="govuk-table__cell govuk-table__cell--word-wrapper">
+        {props.file.type}
+      </td>
       <td className="govuk-table__cell govuk-table__cell--numeric">
         {bytesToSize(props.file.size)}
       </td>

--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
@@ -13,8 +13,11 @@ function HeaderMessage() {
         Unless you are in a team folder, files over 5GB are uploaded
         automatically to the bigdata folder. The upload location is in the table
         below.{' '}
-        <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/your-files/uploading-files-to-your-files/">
-          Find out more about storing files in Your Files.
+        <a
+          href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/your-files/uploading-files-to-your-files/"
+          target="blank"
+        >
+          Find out more about storing files in Your Files (opens in a new tab).
         </a>
       </strong>
     </p>

--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
@@ -17,8 +17,9 @@ function HeaderMessage() {
           href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/your-files/uploading-files-to-your-files/"
           target="blank"
         >
-          Find out more about storing files in Your Files (opens in a new tab).
+          Find out more about storing files in Your Files (opens in new tab)
         </a>
+        .
       </strong>
     </p>
   );

--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
@@ -6,6 +6,21 @@ import { fileQueue } from '../utils';
 import { UploadIcon } from '../icons/upload';
 import Modal from './Modal';
 
+function HeaderMessage() {
+  return (
+    <p className="govuk-body">
+      <strong>
+        Unless you are in a team folder, files over 5GB are uploaded
+        automatically to the bigdata folder. The upload location is in the table
+        below.{' '}
+        <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/your-files/uploading-files-to-your-files/">
+          Find out more about storing files in Your Files
+        </a>
+      </strong>
+    </p>
+  );
+}
+
 function UploadHeaderRow() {
   return (
     <tr className="govuk-table__row">
@@ -208,6 +223,7 @@ export class UploadFilesPopup extends React.Component {
               <div className="modal-contents">
                 <div className="modal-body">
                   <div className="col-md-18">
+                    <HeaderMessage />
                     <div className="panel-body upload-files__table-container">
                       <table
                         className="govuk-table"


### PR DESCRIPTION
### Description of change

This change adds a message to the top of the "Upload files" modal letting users know where the files will be stored depending on what the file sizes are. This message also contains a link that will direct users to the help centre which gives them more information and guidance around uploading files and file size limits.

![Screenshot 2024-04-19 at 11 16 10](https://github.com/uktrade/data-workspace-frontend/assets/10154302/2cbbb666-3bbe-460c-b8ad-ee12de54f56b)

### How to test
1. Visit the file upload tool `/files`
2. choose some files to upload
3. View the message above the table containing files to be uploaded

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?