### PR TITLE
refactor/DT-1923: Update the warning message on the upload files modal

### DIFF
--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/popups/UploadFiles.jsx
@@ -267,18 +267,14 @@ export class UploadFilesPopup extends React.Component {
                       <span className="govuk-warning-text__assistive">
                         Warning
                       </span>
-                      It is your personal responsibility to protect and handle
-                      data appropriately. Data Workspace is not accredited for
-                      SECRET or TOP SECRET information. If you are unsure about
-                      the information security or data protection of this
-                      upload, seek advice on{' '}
-                      <a
-                        className="govuk-link"
-                        href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/guidance/information-classification-and-handling/"
-                      >
-                        information classification and data handling
+                      Do not store SECRET or TOP SECRET data on Data Workspace.
+                      You are responsible for the information security and data
+                      protection of this upload. You can get help from the{' '}
+                      <a href="mailto:security@businessandtrade.gov.uk">
+                        DBT Security Team
                       </a>{' '}
-                      or contact your line manager.
+                      if you are unsure about the Government Security
+                      Classification policy.
                     </strong>
                   </div>
                 </div>


### PR DESCRIPTION
### Description of change
This change updates the warning message on the file upload modal to a shorter message thats clearer to the user.

![Screenshot 2024-04-19 at 13 23 00](https://github.com/uktrade/data-workspace-frontend/assets/10154302/594f2bc8-1f31-4636-8b4c-c650d02fd321)


### How to test
1. List the file upload tool /files
2.  Choose some files to upload
3. View the message below the table containing files to be uploaded

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?