### PR TITLE
fix/dt-1964: Bookmark should show when searching catalogue

### DIFF
--- a/cypress/e2e/data-catalogue/bookmarked.cy.ts
+++ b/cypress/e2e/data-catalogue/bookmarked.cy.ts
@@ -1,0 +1,55 @@
+describe("Bookmarking datasets", () => {
+
+  const assertBookmarked = ()=>{
+    cy.findByRole("heading", {
+      level: 3,
+      name: "Source dataset",
+    }).within(()=>{
+      cy.findByRole("button").should("have.attr", "class", 'bookmark-toggle is-bookmarked');
+      cy.findByRole("button").should("have.attr", "data-dataset-bookmarked", 'true');
+      cy.findByRole("button").should("have.attr", "title", 'You have bookmarked Source dataset');
+    })
+  }
+
+  const assertNotBookmarked = ()=>{
+    cy.findByRole("heading", {
+      level: 3,
+      name: "source dataset - no permissions",
+    }).within(()=>{
+      cy.findByRole("button").should("have.attr", "class", 'bookmark-toggle');
+      cy.findByRole("button").should("have.attr", "data-dataset-bookmarked", 'false');
+      cy.findByRole("button").should("have.attr", "title", 'You have not bookmarked source dataset - no permissions');
+    })
+  }
+
+  context('When directly viewing the data catalogue page', ()=>{
+      beforeEach(()=>{
+        cy.visit('/datasets')
+      })
+
+      it('should show a bookmarked dataset', ()=>{
+        assertBookmarked()
+      })
+
+      it('should NOT show a bookmarked dataset', ()=>{
+        assertNotBookmarked()
+      })
+  })
+
+  context('When searching the data catalogue page', ()=>{
+    beforeEach(()=>{
+      cy.visit('/datasets')
+      cy.findByPlaceholderText("Search by dataset name or description").type(
+        "source"
+      );
+    })
+
+    it('should show a bookmarked dataset', ()=>{
+      assertBookmarked()
+    })
+
+    it('should NOT show a bookmarked dataset', ()=>{
+      assertNotBookmarked()
+    })
+  })
+})

--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -2524,13 +2524,13 @@ function toggleBookmark(toggle, isBookmarked) {
     ? [
         "add",
         "/datasets/" + datasetId + "/set-bookmark",
-        `You have bookmarked ${datasetName}'`,
+        `You have bookmarked ${datasetName}`,
         true,
       ]
     : [
         "remove",
         "/datasets/" + datasetId + "/unset-bookmark",
-        `You have not bookmarked ${datasetName}'`,
+        `You have not bookmarked ${datasetName}`,
         false,
       ];
 

--- a/dataworkspace/dataworkspace/templates/datasets/data_catalogue.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_catalogue.html
@@ -167,7 +167,7 @@
                 {% endif %}
                 <div style="float:right;">
                   <button
-                  type="button" class="bookmark-toggle" 
+                  type="button" class="bookmark-toggle {% if dataset.is_bookmarked %}is-bookmarked{% endif %}" 
                   data-dataset-bookmarked="{% if dataset.is_bookmarked %}true{% else %}false{% endif %}" 
                   data-dataset-id="{{ dataset.id }}" 
                   data-dataset-name="{{ dataset.name }}">


### PR DESCRIPTION
### Description of change
Currently the bookmarked icons are not showing when a user searches within the data catalogue page. However they will show if you visit the data catalogue page directly or reload the search results. This change fixes this bug and will show bookmarked icons on datasets regardless of how you use and view the data catalogue page and its search functionality.

### How to test
1. Visit the data catalogue page `datasets`
2. Bookmark a dataset
3. Reload the page and you should see that the bookmark icon has a solid fill colour indicating that it has been bookmarked
4. Now refine/narrow the search results by entering the title of the dataset you bookmarked
5. You should now see an updated results page with your dataset listed and again, a solid fill colour on the bookmark icon

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?