### PR TITLE
fix: DT-1954 - Table views are not being shown in the data usage component

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v2/datasets/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v2/datasets/serializers.py
@@ -1,11 +1,16 @@
-from django.db.models import Q
+from django.db.models import Q, TextField
 from django.urls import reverse
 from rest_framework import serializers
+
+from django.db.models.functions import Cast
 
 from dataworkspace.apps.datasets.models import (
     DataSet,
     ReferenceDataset,
     VisualisationCatalogueItem,
+)
+from dataworkspace.apps.datasets.constants import (
+    DataSetType,
 )
 from dataworkspace.apps.eventlog.models import EventLog
 
@@ -40,7 +45,25 @@ class DatasetStatsSerializer(serializers.ModelSerializer):
         return f"{obj.average_unique_users_daily:.3f}"
 
     def get_table_views(self, obj):
-        return obj.events.filter(event_type=EventLog.TYPE_DATA_TABLE_VIEW).count()
+        if obj.type == DataSetType.MASTER:
+            source_table_ids = obj.sourcetable_set.annotate(
+                str_id=Cast("id", output_field=TextField())
+            ).values_list("str_id", flat=True)
+            return EventLog.objects.filter(
+                object_id__in=source_table_ids, event_type=EventLog.TYPE_DATA_TABLE_VIEW
+            ).count()
+
+        if obj.type == DataSetType.DATACUT:
+            custom_dataset_table_ids = obj.customdatasetquery_set.annotate(
+                str_id=Cast("id", output_field=TextField())
+            ).values_list("str_id", flat=True)
+            return EventLog.objects.filter(
+                object_id__in=custom_dataset_table_ids,
+                event_type=EventLog.TYPE_DATA_TABLE_VIEW,
+            ).count()
+
+        if obj.type == DataSetType.REFERENCE:
+            return obj.events.filter(event_type=EventLog.TYPE_DATA_TABLE_VIEW).count()
 
     def get_collection_count(self, obj):
         return obj.collection_set.count()

--- a/dataworkspace/dataworkspace/tests/api_v2/datasets/test_dataset_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v2/datasets/test_dataset_views.py
@@ -3,6 +3,7 @@ from random import randint
 import pytest
 from django.urls import reverse
 from rest_framework import status
+import factory.fuzzy
 
 from dataworkspace.apps.datasets.constants import DataSetType
 from dataworkspace.apps.eventlog.models import EventLog
@@ -54,19 +55,18 @@ def test_dataset_detail(client, user, dataset_factory):
     assert response.json() == _dataset_detail(dataset)
 
 
-@pytest.mark.parametrize(
-    "dataset_factory",
-    [
-        factories.DatacutDataSetFactory,
-        factories.MasterDataSetFactory,
-        factories.ReferenceDatasetFactory,
-        factories.VisualisationCatalogueItemFactory,
-    ],
-)
 @pytest.mark.django_db
-def test_dataset_stats(client, user, dataset_factory):
+def test_master_dataset_stats(client, user):
     client.force_login(user)
-    dataset = dataset_factory()
+    dataset = factories.MasterDataSetFactory()
+    source_table = factories.SourceTableFactory(
+        name="my-source",
+        table="table1",
+        dataset=dataset,
+    )
+    num_table_views = randint(0, 5)
+    for _ in range(num_table_views):
+        log_event(factories.UserFactory(), EventLog.TYPE_DATA_TABLE_VIEW, source_table)
 
     num_page_views = randint(0, 5)
     for _ in range(num_page_views):
@@ -78,14 +78,7 @@ def test_dataset_stats(client, user, dataset_factory):
 
     num_collections = randint(0, 5)
     for _ in range(num_collections):
-        if dataset.type == DataSetType.VISUALISATION:
-            factories.CollectionFactory().visualisation_catalogue_items.add(dataset)
-        elif dataset.type == DataSetType.REFERENCE:
-            factories.CollectionFactory().datasets.add(
-                dataset.reference_dataset_inheriting_from_dataset
-            )
-        else:
-            factories.CollectionFactory().datasets.add(dataset)
+        factories.CollectionFactory().datasets.add(dataset)
 
     response = client.get(dataset.get_stats_url())
     assert response.status_code == status.HTTP_200_OK
@@ -93,3 +86,108 @@ def test_dataset_stats(client, user, dataset_factory):
     assert stats["page_views"] == num_page_views
     assert stats["bookmark_count"] == num_bookmarks
     assert stats["collection_count"] == num_collections
+    assert stats["table_views"] == num_table_views
+
+
+@pytest.mark.django_db
+def test_datacut_dataset_stats(client, user):
+    client.force_login(user)
+    dataset = factories.MasterDataSetFactory()
+    database = factories.DatabaseFactory(memorable_name="my_database")
+    query = factories.CustomDatasetQueryFactory(
+        dataset=dataset,
+        database=database,
+        query="SELECT * FROM table1 order by id desc limit 10",
+    )
+
+    num_table_views = randint(0, 5)
+    for _ in range(num_table_views):
+        log_event(factories.UserFactory(), EventLog.TYPE_DATA_TABLE_VIEW, query)
+
+    num_page_views = randint(0, 5)
+    for _ in range(num_page_views):
+        log_event(factories.UserFactory(), EventLog.TYPE_DATASET_VIEW, dataset)
+
+    num_bookmarks = randint(0, 5)
+    for _ in range(num_bookmarks):
+        dataset.set_bookmark(factories.UserFactory())
+
+    num_collections = randint(0, 5)
+    for _ in range(num_collections):
+        factories.CollectionFactory().datasets.add(dataset)
+
+    response = client.get(dataset.get_stats_url())
+    assert response.status_code == status.HTTP_200_OK
+    stats = response.json()
+    assert stats["page_views"] == num_page_views
+    assert stats["bookmark_count"] == num_bookmarks
+    assert stats["collection_count"] == num_collections
+    assert stats["table_views"] == num_table_views
+
+
+@pytest.mark.django_db
+def test_ref_dataset_stats(client, user):
+    client.force_login(user)
+    dataset = factories.ReferenceDatasetFactory.create(
+        name="refds1", table_name="table1"
+    )
+
+    num_table_views = randint(0, 5)
+    for _ in range(num_table_views):
+        log_event(factories.UserFactory(), EventLog.TYPE_DATA_TABLE_VIEW, dataset)
+
+    num_page_views = randint(0, 5)
+    for _ in range(num_page_views):
+        log_event(factories.UserFactory(), EventLog.TYPE_DATASET_VIEW, dataset)
+
+    num_bookmarks = randint(0, 5)
+    for _ in range(num_bookmarks):
+        dataset.set_bookmark(factories.UserFactory())
+
+    num_collections = randint(0, 5)
+    for _ in range(num_collections):
+        factories.CollectionFactory().datasets.add(
+            dataset.reference_dataset_inheriting_from_dataset
+        )
+
+    response = client.get(dataset.get_stats_url())
+    assert response.status_code == status.HTTP_200_OK
+    stats = response.json()
+    assert stats["page_views"] == num_page_views
+    assert stats["bookmark_count"] == num_bookmarks
+    assert stats["collection_count"] == num_collections
+    assert stats["table_views"] == num_table_views
+
+
+@pytest.mark.django_db
+def test_visualistaion_stats(client, user):
+    client.force_login(user)
+    dataset = factories.VisualisationCatalogueItemFactory()
+
+    num_dashboard_views = randint(0, 5)
+    for _ in range(num_dashboard_views):
+        log_event(
+            factories.UserFactory(),
+            EventLog.TYPE_VIEW_QUICKSIGHT_VISUALISATION,
+            dataset,
+        )
+
+    num_page_views = randint(0, 5)
+    for _ in range(num_page_views):
+        log_event(factories.UserFactory(), EventLog.TYPE_DATASET_VIEW, dataset)
+
+    num_bookmarks = randint(0, 5)
+    for _ in range(num_bookmarks):
+        dataset.set_bookmark(factories.UserFactory())
+
+    num_collections = randint(0, 5)
+    for _ in range(num_collections):
+        factories.CollectionFactory().visualisation_catalogue_items.add(dataset)
+
+    response = client.get(dataset.get_stats_url())
+    assert response.status_code == status.HTTP_200_OK
+    stats = response.json()
+    assert stats["page_views"] == num_page_views
+    assert stats["bookmark_count"] == num_bookmarks
+    assert stats["collection_count"] == num_collections
+    assert stats["dashboard_views"] == num_dashboard_views


### PR DESCRIPTION
### Description of change
Currently the "Data Usage" component thats mounted on the catalogue item pages is broken and we are not showing any "Table views" for master source sets and data cuts. This change fixes the issue and wraps more tests around the API endpoint.

### How to test
1. Open a "Master/Source set dataset" catalogue item.
2. Scroll down to the "Data usage" component.
3. Take a note of the current "Table views" count.
4. Click on any of the tables listed on the page.
5. Return to the catalogue item page.
6. Notice that the count for table views have increased by one.

Repeat steps 1 - 6 for data cut, reference dataset and a visualisation catalogue items. Note: Visualisation catalogue items will not show "Table views", you will see "Dashboard views" instead.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Have E2E tests been added to cover any React changes?
* [x] Have Accessibility tests been added to cover any React changes?