### PR TITLE
fix/DT-1931 update status tag style to match gds/data workspace

### DIFF
--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
@@ -209,14 +209,14 @@
 .progress-percentage-complete {
   font-size: 14px;
 }
-.progress-percentage-complete {
-  color: #005a30;
-  background: #cce2d8;
-}
 .progress-percentage {
   color: #144e81;
   background: #d2e2f1;
   font-variant-numeric: tabular-nums;
+}
+.progress-percentage-complete {
+  color: #005a30;
+  background: #cce2d8;
 }
 .progress-error {
 

--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
@@ -216,8 +216,6 @@
 }
 .progress-percentage {
   font-variant-numeric: tabular-nums;
-  color: #144e81;
-  background: #d2e2f1;
 }
 .progress-error {
   // background: #d4351c;

--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
@@ -210,15 +210,14 @@
   font-size: 14px;
 }
 .progress-percentage-complete {
-  // background: #00703c;
-  color: #005a30;
+    color: #005a30;
   background: #cce2d8;
 }
 .progress-percentage {
   font-variant-numeric: tabular-nums;
 }
 .progress-error {
-  // background: #d4351c;
+
   color: #942514;
   background: #f6d7d2;
   text-transform: none;

--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
@@ -210,10 +210,12 @@
   font-size: 14px;
 }
 .progress-percentage-complete {
-    color: #005a30;
+  color: #005a30;
   background: #cce2d8;
 }
 .progress-percentage {
+  color: #144e81;
+  background: #d2e2f1;
   font-variant-numeric: tabular-nums;
 }
 .progress-error {

--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
@@ -210,13 +210,17 @@
   font-size: 14px;
 }
 .progress-percentage-complete {
-  background: #00703c;
+  // background: #00703c;
+  color: #005a30;
+  background: #cce2d8;
 }
 .progress-percentage {
   font-variant-numeric: tabular-nums;
 }
 .progress-error {
-  background: #d4351c;
+  // background: #d4351c;
+  color: #942514;
+  background: #f6d7d2;
   text-transform: none;
   letter-spacing: 0;
 }
@@ -263,9 +267,11 @@
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
 }
 .modal-header {
-  background-color: #005ea5;
-  color: #ffffff;
+  // background-color: #005ea5;
+  // color: #ffffff;
   padding: 15px;
+  color: #144e81;
+  background: #d2e2f1;
 }
 .modal-header button.close {
   color: #ffffff;

--- a/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
+++ b/dataworkspace/dataworkspace/static/js/react/features/your-files/App.scss
@@ -216,6 +216,8 @@
 }
 .progress-percentage {
   font-variant-numeric: tabular-nums;
+  color: #144e81;
+  background: #d2e2f1;
 }
 .progress-error {
   // background: #d4351c;
@@ -267,11 +269,9 @@
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
 }
 .modal-header {
-  // background-color: #005ea5;
-  // color: #ffffff;
+  background-color: #005ea5;
+  color: #ffffff;
   padding: 15px;
-  color: #144e81;
-  background: #d2e2f1;
 }
 .modal-header button.close {
   color: #ffffff;


### PR DESCRIPTION
### Description of change

This PR is to update status tag style. We want to amend these for consistency and for best practice to follow GDS equivalent, but also Data Workspace equivalent:

### Here are GDS/ Data Workspace styles that are adopted on your file status tags

![image](https://github.com/uktrade/data-workspace-frontend/assets/94635933/4f4915bb-ec05-459e-a410-41cd140b7528)

![image](https://github.com/uktrade/data-workspace-frontend/assets/94635933/3bf2962f-36f3-4b31-8dc8-13f65afef481)

![image](https://github.com/uktrade/data-workspace-frontend/assets/94635933/49715dd6-0af3-4031-998f-6084b48db0b6)

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?