### PR TITLE
feat: DT-1834 add option to generate an Id column

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/manager/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/manager/views.py
@@ -111,6 +111,11 @@ class DatasetManageSourceTableColumnConfigView(DatasetManageSourceTableView):
     def form_valid(self, form):
         source = self._get_source()
         cleaned = form.cleaned_data
+        include_column_id = False
+
+        if "auto_generate_id_column" in cleaned and cleaned["auto_generate_id_column"] != "":
+            include_column_id = cleaned["auto_generate_id_column"] == "True"
+
         columns = get_s3_csv_column_types(cleaned["path"])
         for field in columns:
             field["data_type"] = SCHEMA_POSTGRES_DATA_TYPE_MAP.get(
@@ -125,7 +130,9 @@ class DatasetManageSourceTableColumnConfigView(DatasetManageSourceTableView):
             "schema_name": source.schema,
             "table_name": source.table,
             "column_definitions": columns,
+            "auto_generate_id_column": include_column_id,
         }
+
         try:
             response = trigger_dataflow_dag(
                 conf,

--- a/dataworkspace/dataworkspace/apps/your_files/views.py
+++ b/dataworkspace/dataworkspace/apps/your_files/views.py
@@ -315,6 +315,7 @@ class CreateTableConfirmDataTypesView(ValidateSchemaMixin, FormView):
 
     def form_valid(self, form):
         cleaned = form.cleaned_data
+        include_column_id = False
 
         file_info = get_s3_csv_file_info(cleaned["path"])
 
@@ -332,12 +333,17 @@ class CreateTableConfirmDataTypesView(ValidateSchemaMixin, FormView):
 
         filename = cleaned["path"].split("/")[-1]
         logger.debug(filename)
+
+        if "auto_generate_id_column" in cleaned and cleaned["auto_generate_id_column"] != "":
+            include_column_id = cleaned["auto_generate_id_column"] == "True"
+
         conf = {
             "file_path": import_path,
             "schema_name": cleaned["schema"],
             "table_name": cleaned["table_name"],
             "column_definitions": file_info["column_definitions"],
             "encoding": file_info["encoding"],
+            "auto_generate_id_column": include_column_id,
         }
         if waffle.switch_is_active(settings.INCREMENTAL_S3_IMPORT_PIPELINE_FLAG):
             conf["incremental"] = (

--- a/dataworkspace/dataworkspace/templates/datasets/manager/manage_source_table_column_config.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manager/manage_source_table_column_config.html
@@ -82,6 +82,10 @@
             {% endfor %}
           </tbody>
         </table>
+        {% if form.show_id_form %}
+          {{ form.auto_generate_id_column }}
+        {% endif %}
+        <br />
         <button type="submit" class="govuk-button">Continue</button>
       </form>
     </div>

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-confirm-data-types.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-confirm-data-types.html
@@ -39,6 +39,10 @@
             {% endfor %}
           </tbody>
         </table>
+        {% if form.show_id_form %}
+          {{ form.auto_generate_id_column }}
+        {% endif %}
+        <br />
         <button type="submit" class="govuk-button">Continue</button>
       </form>
     </div>

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4684,6 +4684,7 @@ class TestDatasetManagerViews:
                 "schema_name": source.schema,
                 "table_name": source.table,
                 "column_definitions": mock_get_column_types.return_value,
+                "auto_generate_id_column": False,
             },
             "DataWorkspaceS3ImportPipeline",
             "test-table1-2021-01-01T01:01:01",

--- a/dataworkspace/dataworkspace/tests/your_files/test_views.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_views.py
@@ -508,9 +508,9 @@ class TestCreateTableViews:
         assert b"Do you want to generate an ID column?" not in response.content
         assert (
             b"This will add an ID column and assign an ID to each row in your table."
-            in response.content
+            not in response.content
         )
-        assert b"The ID will be an increasing integer, e.g. 1, 2, 3." in response.content
+        assert b"The ID will be an increasing integer, e.g. 1, 2, 3." not in response.content
 
     @freeze_time("2021-01-01 01:01:01")
     @mock.patch("dataworkspace.apps.your_files.views.get_schema_for_user")

--- a/dataworkspace/dataworkspace/tests/your_files/test_views.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_views.py
@@ -176,6 +176,7 @@ class TestCreateTableViews:
                 "table_name": "a_csv",
                 "encoding": file_info_return_value["encoding"],
                 "column_definitions": file_info_return_value["column_definitions"],
+                "auto_generate_id_column": False,
             },
             "DataWorkspaceS3ImportPipeline",
             "test_schema-a_csv-2021-01-01T01:01:01",
@@ -417,6 +418,100 @@ class TestCreateTableViews:
         assert response.status_code == 200
         assert b"schema &quot;public&quot; already exists" in response.content
 
+    @mock.patch("dataworkspace.apps.your_files.views.get_schema_for_user")
+    @mock.patch("dataworkspace.apps.your_files.views.get_team_schemas_for_user")
+    @mock.patch("dataworkspace.apps.your_files.views.get_s3_csv_file_info")
+    @mock.patch("dataworkspace.apps.your_files.forms.get_user_s3_prefixes")
+    def test_auto_generate_id_option_exists(
+        self,
+        mock_get_s3_prefix,
+        mock_get_file_info,
+        mock_get_team_schemas_for_user,
+        mock_get_schema_for_user,
+        client,
+    ):
+        mock_get_schema_for_user.return_value = "test_schema"
+        mock_get_team_schemas_for_user.return_value = [
+            {"name": "TestTeam", "schema_name": "test_team_schema"},
+        ]
+        mock_get_s3_prefix.return_value = {"home": "user/federated/abc"}
+        file_info_return_value = {
+            "encoding": "utf-8-sig",
+            "column_definitions": [
+                {
+                    "header_name": "Field 1",
+                    "column_name": "field1",
+                    "data_type": "text",
+                    "sample_data": [1, 2, 3],
+                }
+            ],
+        }
+        mock_get_file_info.return_value = file_info_return_value
+
+        params = {
+            "path": "user/federated/abc/a-csv.csv",
+            "table_name": "test_table",
+            "schema": "test_team_schema",
+        }
+        response = client.get(
+            f'{reverse("your-files:create-table-confirm-data-types")}?{urlencode(params)}',
+        )
+
+        print(response.content)
+
+        assert b"Do you want to generate an ID column?" in response.content
+        assert (
+            b"This will add an ID column and assign an ID to each row in your table."
+            in response.content
+        )
+        assert b"The ID will be an increasing integer, e.g. 1, 2, 3." in response.content
+
+    @mock.patch("dataworkspace.apps.your_files.views.get_schema_for_user")
+    @mock.patch("dataworkspace.apps.your_files.views.get_team_schemas_for_user")
+    @mock.patch("dataworkspace.apps.your_files.views.get_s3_csv_file_info")
+    @mock.patch("dataworkspace.apps.your_files.forms.get_user_s3_prefixes")
+    def test_auto_generate_id_option_does_not_exist(
+        self,
+        mock_get_s3_prefix,
+        mock_get_file_info,
+        mock_get_team_schemas_for_user,
+        mock_get_schema_for_user,
+        client,
+    ):
+        mock_get_schema_for_user.return_value = "test_schema"
+        mock_get_team_schemas_for_user.return_value = [
+            {"name": "TestTeam", "schema_name": "test_team_schema"},
+        ]
+        mock_get_s3_prefix.return_value = {"home": "user/federated/abc"}
+        file_info_return_value = {
+            "encoding": "utf-8-sig",
+            "column_definitions": [
+                {
+                    "header_name": "Field 1",
+                    "column_name": "id",
+                    "data_type": "text",
+                    "sample_data": [1, 2, 3],
+                }
+            ],
+        }
+        mock_get_file_info.return_value = file_info_return_value
+
+        params = {
+            "path": "user/federated/abc/a-csv.csv",
+            "table_name": "test_table",
+            "schema": "test_team_schema",
+        }
+        response = client.get(
+            f'{reverse("your-files:create-table-confirm-data-types")}?{urlencode(params)}',
+        )
+
+        assert b"Do you want to generate an ID column?" not in response.content
+        assert (
+            b"This will add an ID column and assign an ID to each row in your table."
+            in response.content
+        )
+        assert b"The ID will be an increasing integer, e.g. 1, 2, 3." in response.content
+
     @freeze_time("2021-01-01 01:01:01")
     @mock.patch("dataworkspace.apps.your_files.views.get_schema_for_user")
     @mock.patch("dataworkspace.apps.your_files.views.get_team_schemas_for_user")
@@ -483,6 +578,7 @@ class TestCreateTableViews:
                 "table_name": "a_csv",
                 "encoding": file_info_return_value["encoding"],
                 "column_definitions": file_info_return_value["column_definitions"],
+                "auto_generate_id_column": False,
             },
             "DataWorkspaceS3ImportPipeline",
             "test_team_schema-a_csv-2021-01-01T01:01:01",
@@ -556,6 +652,7 @@ class TestCreateTableViews:
                 "table_name": "a_csv",
                 "encoding": file_info_return_value["encoding"],
                 "column_definitions": file_info_return_value["column_definitions"],
+                "auto_generate_id_column": False,
             },
             "DataWorkspaceS3ImportPipeline",
             "public-a_csv-2021-01-01T01:01:01",


### PR DESCRIPTION
### Description of change
This change enable users to auto generate an ID column when creating new tables from CSV's.

### How to test

Before testing both journeys create two CSV files. One that includes an ID column and one that doesn't.

**Catalogue page journey**
1. On the catalogue choose a source dataset that you have access to
2. Within the "Data Tables" section, alongside a table in the list click "Update or restore table"
3. Click the "Choose file" button and upload the CSV file that doesn't have the ID column and click "Upload CSV"
4. Scroll to the bottom of the page and where it says "Do you want to generate an ID column?" click "yes" and submit
5. After the new table has been created go back to the data catalogue page and click on the table you updated
6. You should now see a new ID column generated in the table

Repeat steps 1 - 6 but this time choose the CSV file with an ID. When you get to step 4 you shouldn't see any option that asks "Do you want to generate an ID column?"

**Your files journey**
1. Go to the "Your files" app `/files`
2. Upload a CSV file that doesn't have the ID column
3. Once the file is uploaded click the "Create table" link
4. On the "Create a table" page just click "Continue"
5. Choose the schema for your table
6. Name your table
7. Scroll to the bottom of the page and where it says "Do you want to generate an ID column?" click "yes" and submit
8. After the new table has been created view the table by clicking "Open data Explorer" and run the SQL
9. You should now see a new ID column generated in the table

Repeat steps 1 - 9 but this time choose the CSV file with an ID. When you get to step 7 you shouldn't see any option that asks "Do you want to generate an ID column?"


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?