### PR TITLE
refactor: use pg-sync-roles for creating and maintaing database users

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -365,6 +365,8 @@ pep517==0.10.0
     # via pip-tools
 pexpect==4.8.0
     # via ipython
+pg-sync-roles==0.0.29
+    # via -r requirements.txt
 pglast==3.10
     # via -r requirements.txt
 pickleshare==0.7.5
@@ -551,6 +553,7 @@ sqlalchemy==2.0.12
     #   -r requirements.txt
     #   django-db-connection-pool
     #   geoalchemy2
+    #   pg-sync-roles
     #   tabulator
 sqlparams==6.0.1
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -34,8 +34,9 @@ kaleido
 mohawk
 notifications-python-client
 paste
-plotly
+pg-sync-roles
 pglast
+plotly
 psutil
 psycogreen
 python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -199,6 +199,8 @@ packaging==22.0
     # via bleach
 paste==3.4.3
     # via -r requirements.in
+pg-sync-roles==0.0.29
+    # via -r requirements.in
 pglast==3.10
     # via -r requirements.in
 plotly==5.6.0
@@ -283,6 +285,7 @@ sqlalchemy==2.0.12
     #   -r requirements.in
     #   django-db-connection-pool
     #   geoalchemy2
+    #   pg-sync-roles
     #   tabulator
 sqlparams==6.0.1
     # via django-db-connection-pool


### PR DESCRIPTION
### Description of change

This is technically a refactor given the existing behaviour of pg-sync-roles, and it doesn't give _that_ much. However, in later changes we'll

- Be moving more logic into pg-sync-roles
- Fixing an issue that results in an accumulation of roles on tables

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?