### PR TITLE
fix: accept multiple secure websocket protocols

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -804,9 +804,11 @@ async def async_main():
 
     async def handle_websocket(downstream_request, upstream_headers, upstream_url):
         request_protocols = downstream_request.headers.get("Sec-WebSocket-Protocol")
-        response_protocols = tuple(
-            protocol.strip() for protocol in request_protocols.split(',')
-        ) if request_protocols else ()
+        response_protocols = (
+            tuple(protocol.strip() for protocol in request_protocols.split(","))
+            if request_protocols
+            else ()
+        )
 
         async def proxy_msg(msg, to_ws):
             if msg.type == aiohttp.WSMsgType.TEXT:
@@ -824,9 +826,7 @@ async def async_main():
         async def upstream():
             try:
                 async with client_session.ws_connect(
-                    str(upstream_url),
-                    headers=upstream_headers,
-                    protocols=response_protocols
+                    str(upstream_url), headers=upstream_headers, protocols=response_protocols
                 ) as upstream_ws:
                     upstream_connection.set_result(upstream_ws)
                     downstream_ws = await downstream_connection
@@ -857,9 +857,7 @@ async def async_main():
             upstream_ws = await upstream_connection
             _, _, _, with_session_cookie = downstream_request[SESSION_KEY]
             downstream_ws = await with_session_cookie(
-                web.WebSocketResponse(
-                    protocols=response_protocols, heartbeat=30
-                )
+                web.WebSocketResponse(protocols=response_protocols, heartbeat=30)
             )
 
             await downstream_ws.prepare(downstream_request)


### PR DESCRIPTION
### Description of change

We have a known streamlit bug in Data Workspace Visualisation in which we can't deploy a streamlit app based on streamlit version > 1.28. The visualisation, in preview and in deployment, would not load on Chrome, unlike Safari and Firefox.

streamlit runs on a host of websockets to provide interactivity. Data Workspace, when reverse proxying connections, handles the [websocket protocol upgrade mechanism](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism) by only expecting [one](https://github.com/uktrade/data-workspace-frontend/blob/52ba47019e869c21b2739bc4cf0b984c947c2fe6/dataworkspace/proxy.py#L806C1-L807C52) incoming subprotocol, while multiple subprotocol upgrades may be [requested](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism).

streamlit, [starting with version 1.29](https://github.com/streamlit/streamlit/commit/fd1037ba61560d2aadec0894cfe43ff6586c9530), establishes websocket handshakes with 2 subprotocols. Safari and Firefox seem to be able to unwrap the subprotocols while Chrome does not.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?