### PR TITLE
feat/DT-1990: Add inline feedback component

### DIFF
--- a/dataworkspace/dataworkspace/static/js/react/components/InlineFeedback/InlineFeedback.stories.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/components/InlineFeedback/InlineFeedback.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { InlineFeedback } from '../index';
+import { ChildForm, mockPostFeedback, mockRejectPostFeedback } from './mocks';
+
+const meta = {
+  title: 'Forms',
+  component: InlineFeedback
+} satisfies Meta<typeof InlineFeedback>;
+export default meta;
+
+type Story = StoryObj<typeof InlineFeedback>;
+
+export const InlineFeedbackForm: Story = {
+  args: {
+    title: 'Was this page helpful?',
+    location: 'data-catalogue',
+    successMessage:
+      'Thanks for letting us know, your response has been recorded',
+    postFeedback: mockPostFeedback
+  }
+};
+
+export const InlineFeedbackFormWithError: Story = {
+  args: {
+    title: 'Was this page helpful?',
+    location: 'data-catalogue',
+    successMessage:
+      'Thanks for letting us know, your response has been recorded',
+    postFeedback: mockRejectPostFeedback
+  }
+};
+
+export const InlineFeedbackWithChildForm: Story = {
+  render: (args) => {
+    return (
+      <InlineFeedback {...args}>
+        {(location, wasItHelpful) => (
+          <ChildForm location={location} wasItHelpful={wasItHelpful} />
+        )}
+      </InlineFeedback>
+    );
+  },
+  args: {
+    title: 'Was this page helpful?',
+    location: 'data-catalogue',
+    successMessage:
+      'Thanks for letting us know, your response has been recorded',
+    postFeedback: mockPostFeedback
+  }
+};

--- a/dataworkspace/dataworkspace/static/js/react/components/InlineFeedback/InlineFeedback.test.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/components/InlineFeedback/InlineFeedback.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+import InlineFeedback from '.';
+import { ChildForm, mockPostFeedback, mockRejectPostFeedback } from './mocks';
+
+const props = {
+  title: 'Was this page helpful?',
+  location: 'data-catalogue',
+  successMessage: 'Thanks for letting us know, your response has been recorded',
+  postFeedback: mockPostFeedback
+};
+
+describe('InlineFeedback', () => {
+  describe('without additional form', () => {
+    it('should render a feedback question with two options', () => {
+      const setUp = () => render(<InlineFeedback {...props} />);
+      const { getByRole } = setUp();
+      expect(
+        getByRole('heading', {
+          name: 'Was this page helpful?',
+          level: 2
+        })
+      ).toBeInTheDocument();
+      expect(getByRole('button', { name: 'Yes' })).toBeInTheDocument();
+      expect(getByRole('button', { name: 'No' })).toBeInTheDocument();
+    });
+    it('should render a success message when an option is submitted', async () => {
+      const setUp = () => render(<InlineFeedback {...props} />);
+      const { getByRole } = setUp();
+      fireEvent.click(getByRole('button', { name: 'Yes' }));
+      await waitFor(() => {
+        expect(
+          getByRole('heading', {
+            name: 'Thanks for letting us know, your response has been recorded',
+            level: 2
+          })
+        ).toBeInTheDocument();
+      });
+    });
+  });
+  describe('with additional form', () => {
+    it('should render a second form after the "yes" button has been submitted', async () => {
+      const setUp = () =>
+        render(
+          <InlineFeedback {...props}>
+            {(location, wasItHelpful) => (
+              <ChildForm location={location} wasItHelpful={wasItHelpful} />
+            )}
+          </InlineFeedback>
+        );
+      const { getByRole } = setUp();
+      fireEvent.click(getByRole('button', { name: 'Yes' }));
+      await waitFor(() => {
+        expect(
+          getByRole('heading', {
+            name: 'Thanks for letting us know, your response has been recorded',
+            level: 2
+          })
+        ).toBeInTheDocument();
+        expect(
+          getByRole('heading', {
+            name: 'Thats great. Can you tell us more about the data-catalogue page? (optional)',
+            level: 3
+          })
+        ).toBeInTheDocument();
+        expect(
+          getByRole('checkbox', {
+            name: 'Yes option 1'
+          })
+        ).toBeInTheDocument();
+        expect(
+          getByRole('checkbox', {
+            name: 'Yes option 2'
+          })
+        ).toBeInTheDocument();
+      });
+    });
+    it('should render a second form after the "no" button has been submitted', async () => {
+      const setUp = () =>
+        render(
+          <InlineFeedback {...props}>
+            {(location, wasItHelpful) => (
+              <ChildForm location={location} wasItHelpful={wasItHelpful} />
+            )}
+          </InlineFeedback>
+        );
+      const { getByRole } = setUp();
+      fireEvent.click(getByRole('button', { name: 'No' }));
+      await waitFor(() => {
+        expect(
+          getByRole('heading', {
+            name: 'Thanks for letting us know, your response has been recorded',
+            level: 2
+          })
+        ).toBeInTheDocument();
+        expect(
+          getByRole('heading', {
+            name: 'Sorry to hear about that. How can we help make the data-catalogue page better? (optional)',
+            level: 3
+          })
+        ).toBeInTheDocument();
+        expect(
+          getByRole('checkbox', {
+            name: 'No option 1'
+          })
+        ).toBeInTheDocument();
+        expect(
+          getByRole('checkbox', {
+            name: 'No option 2'
+          })
+        ).toBeInTheDocument();
+      });
+    });
+  });
+  describe('with error', () => {
+    it('should render an error message if the submission was to fail', async () => {
+      const setUp = () =>
+        render(
+          <InlineFeedback {...props} postFeedback={mockRejectPostFeedback} />
+        );
+      const { getByRole, getByText } = setUp();
+      fireEvent.click(getByRole('button', { name: 'Yes' }));
+      await waitFor(() => {
+        expect(
+          getByText('Error: Oh no something went wrong!')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/dataworkspace/dataworkspace/static/js/react/components/InlineFeedback/index.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/components/InlineFeedback/index.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+
+import Button from '@govuk-react/button';
+import { SPACING_POINTS } from '@govuk-react/constants';
+import { H2 } from '@govuk-react/heading';
+import { typography } from '@govuk-react/lib';
+import LoadingBox from '@govuk-react/loading-box';
+import styled from 'styled-components';
+
+import { BLACK, ERROR_COLOUR, LIGHT_GREY } from '../../constants';
+
+const StyledForm = styled('form')`
+  display: inline-flex;
+  align-items: center;
+  h2 {
+    margin: 0 ${SPACING_POINTS[5]}px 0 0;
+  }
+  button {
+    margin: 0;
+  }
+  button:first-of-type {
+    margin-right: ${SPACING_POINTS[4]}px;
+  }
+`;
+
+const ErrorMessage = styled('p')`
+  ${typography.font({ size: 19 })};
+  margin: 0;
+  color: ${ERROR_COLOUR};
+`;
+
+export type PostFeedback = (
+  location: string,
+  wasItHelpful: boolean
+) => Promise<void>;
+
+export type InlineFeedbackProps = {
+  title: string;
+  location: string;
+  successMessage: string;
+  postFeedback: PostFeedback;
+  children?: (location: string, wasItHelpful: boolean) => React.ReactNode;
+};
+
+const InlineFeedback: React.FC<InlineFeedbackProps> = ({
+  title,
+  location,
+  successMessage,
+  postFeedback,
+  children
+}) => {
+  const [isSuccessfull, setIsSuccessfull] = useState<boolean>(false);
+  const [loading, setLoading] = useState(false);
+  const [wasItHelpful, setWasItHelpful] = useState<boolean>(false);
+  const [error, setError] = useState<string>();
+  const handleOnClick =
+    (wasItHelpful: boolean) =>
+    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      e.preventDefault();
+      setLoading(true);
+      // we are using then to only catch promise rejection and not other JS errors
+      postFeedback(location, wasItHelpful)
+        .catch((error) => {
+          if (typeof error === 'string') {
+            setError(error);
+          } else {
+            throw new Error(
+              'The postFeedback function must only ever reject with a string'
+            );
+          }
+          setLoading(false);
+        })
+        .then(() => {
+          setIsSuccessfull(true);
+          setWasItHelpful(wasItHelpful);
+          setLoading(false);
+        });
+    };
+  return (
+    <LoadingBox loading={loading}>
+      {error ? (
+        <ErrorMessage data-testid="data-usage-error">
+          Error: {error}
+        </ErrorMessage>
+      ) : isSuccessfull ? (
+        <>
+          <H2 size="MEDIUM">{successMessage}</H2>
+          {children?.(location, wasItHelpful)}
+        </>
+      ) : (
+        <StyledForm>
+          <H2 size="MEDIUM">{title}</H2>
+          <Button
+            buttonColour={LIGHT_GREY}
+            buttonTextColour={BLACK}
+            type="submit"
+            onClick={handleOnClick(true)}
+          >
+            Yes
+          </Button>
+          <Button
+            buttonColour={LIGHT_GREY}
+            buttonTextColour={BLACK}
+            type="submit"
+            onClick={handleOnClick(false)}
+          >
+            No
+          </Button>
+        </StyledForm>
+      )}
+    </LoadingBox>
+  );
+};
+
+export default InlineFeedback;

--- a/dataworkspace/dataworkspace/static/js/react/components/InlineFeedback/mocks.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/components/InlineFeedback/mocks.tsx
@@ -1,0 +1,51 @@
+import Button from '@govuk-react/button';
+import Checkbox from '@govuk-react/checkbox';
+import { H3 } from '@govuk-react/heading';
+
+import type { PostFeedback } from './index';
+
+export const mockPostFeedback: PostFeedback = () => {
+  return new Promise((resolve) => {
+    setTimeout(resolve);
+  });
+};
+
+export const mockRejectPostFeedback: PostFeedback = () => {
+  return new Promise((_resolve, reject) =>
+    setTimeout(reject, 0, 'Oh no something went wrong!')
+  );
+};
+
+export const ChildForm = ({
+  location,
+  wasItHelpful
+}: {
+  location: string;
+  wasItHelpful: boolean;
+}) => {
+  return (
+    <form>
+      {wasItHelpful ? (
+        <>
+          <H3 size="SMALL">
+            Thats great. Can you tell us more about the {location} page?
+            (optional)
+          </H3>
+          <Checkbox name="option">Yes option 1</Checkbox>
+          <Checkbox name="option">Yes option 2</Checkbox>
+        </>
+      ) : (
+        <>
+          <H3 size="SMALL">
+            Sorry to hear about that. How can we help make the {location} page
+            better? (optional)
+          </H3>
+          <Checkbox name="option">No option 1</Checkbox>
+          <Checkbox name="option">No option 2</Checkbox>
+        </>
+      )}
+      <br />
+      <Button>Submit</Button>
+    </form>
+  );
+};

--- a/dataworkspace/dataworkspace/static/js/react/components/index.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/components/index.tsx
@@ -3,3 +3,4 @@ export { default as FetchDataContainer } from './FetchDataContainer';
 export { default as Tile } from './Tile';
 export { default as Main } from './Main';
 export { default as InnerContainer } from './InnerContainer';
+export { default as InlineFeedback } from './InlineFeedback';

--- a/dataworkspace/dataworkspace/static/js/react/constants.ts
+++ b/dataworkspace/dataworkspace/static/js/react/constants.ts
@@ -1,7 +1,9 @@
 export const API_BASE_URL = 'api/v2';
 
 export const ERROR_COLOUR = '#d4351c';
+export const BLACK = '#0b0c0c';
 export const GREY_4 = '#f8f8f8';
+export const LIGHT_GREY = '#f3f2f1';
 export const MID_GREY = '#b1b4b6';
 export const WHITE = '#ffffff';
 export const BLUE = '#1d70b8';


### PR DESCRIPTION
Ticket [DT-1990](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-1990) 

### Description of change
This change adds a new inline feedback component which will initially be mounted on the data catalogue page. This component will help collect data around how helpful the page is to the user and how we could improve it. This change ONLY adds the component to the codebase so its not being surfaced anywhere in the UI.

### How to test

To view the component you will need the codebase running locally. Then follow these steps:

1. cd into `dataworkspace/dataworkspace/static/js` 
2. Open terminal and run `npm run storybook`
3. Once Storybook is running you will be able to navigate to the component

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?

[DT-1990]: https://uktrade.atlassian.net/browse/DT-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ