### PR TITLE
Amend regex in basepipeline form to disallow capital letters

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/forms.py
@@ -51,9 +51,9 @@ class BasePipelineCreateForm(GOVUKDesignSystemModelForm):
         error_messages={"required": "Enter a table name."},
         validators=(
             RegexValidator(
-                message='Table name must be in the format schema.table or "schema"."table"',
-                regex=r"^((\"[a-zA-Z_-][a-zA-Z0-9_-]*\")|([a-zA-Z_-][a-zA-Z0-9_-]*))"
-                r"\.((\"[a-zA-Z_-][a-zA-Z0-9_-]*\")|([a-zA-Z_-][a-zA-Z0-9_-]*))$",
+                message='Table name must be lower case in the format schema.table or "schema"."table"',
+                regex=r"^((\"[a-z_-][a-z0-9_-]*\")|([a-z_-][a-z0-9_-]*))"
+                r"\.((\"[a-z_-][a-z0-9_-]*\")|([a-z_-][a-z0-9_-]*))$",
             ),
             validate_schema_and_table,
         ),

--- a/dataworkspace/dataworkspace/tests/datasets/test_pipelines.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_pipelines.py
@@ -14,7 +14,12 @@ from dataworkspace.tests import factories
     (
         (
             "no_dot",
-            "Table name must be in the format schema.table or &quot;schema&quot;.&quot;table&quot;",
+            "Table name must be lower case in the format schema.table or &quot;schema&quot;.&quot;table&quot;",
+            0,
+        ),
+        (
+            "CAPITAL.table",
+            "Table name must be lower case in the format schema.table or &quot;schema&quot;.&quot;table&quot;",
             0,
         ),
         (


### PR DESCRIPTION
### Description of change

Removed capital letters in regex validator for the basepipeline class so that lower case table names is now enforced.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?