### PR TITLE
refactor: remove unnecessary settings on database roles

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -295,37 +295,35 @@ def new_private_database_credentials(
                 )
             )
 
-            # Give the roles reasonable timeouts...
-            # [Out of paranoia on all roles in case the user change role mid session]
-            for _db_user in [db_role, db_user] + db_shared_roles:
-                cur.execute(
-                    sql.SQL(
-                        "ALTER USER {} SET idle_in_transaction_session_timeout = '60min';"
-                    ).format(sql.Identifier(_db_user))
+            # Give the user reasonable timeouts
+            cur.execute(
+                sql.SQL("ALTER USER {} SET idle_in_transaction_session_timeout = '60min';").format(
+                    sql.Identifier(db_user)
                 )
-                cur.execute(
-                    sql.SQL("ALTER USER {} SET statement_timeout = '60min';").format(
-                        sql.Identifier(_db_user)
-                    )
+            )
+            cur.execute(
+                sql.SQL("ALTER USER {} SET statement_timeout = '60min';").format(
+                    sql.Identifier(db_user)
                 )
-                cur.execute(
-                    sql.SQL("ALTER USER {} SET pgaudit.log = {};").format(
-                        sql.Identifier(_db_user),
-                        sql.Literal(settings.PGAUDIT_LOG_SCOPES),
-                    )
+            )
+            cur.execute(
+                sql.SQL("ALTER USER {} SET pgaudit.log = {};").format(
+                    sql.Identifier(db_user),
+                    sql.Literal(settings.PGAUDIT_LOG_SCOPES),
                 )
-                cur.execute(
-                    sql.SQL("ALTER USER {} SET pgaudit.log_catalog = off;").format(
-                        sql.Identifier(_db_user),
-                        sql.Literal(settings.PGAUDIT_LOG_SCOPES),
-                    )
+            )
+            cur.execute(
+                sql.SQL("ALTER USER {} SET pgaudit.log_catalog = off;").format(
+                    sql.Identifier(db_user),
+                    sql.Literal(settings.PGAUDIT_LOG_SCOPES),
                 )
-                cur.execute(
-                    sql.SQL("ALTER USER {} WITH CONNECTION LIMIT {};").format(
-                        sql.Identifier(_db_user),
-                        sql.Literal(50 if db_user.endswith("_qs") else 10),
-                    )
+            )
+            cur.execute(
+                sql.SQL("ALTER USER {} WITH CONNECTION LIMIT {};").format(
+                    sql.Identifier(db_user),
+                    sql.Literal(50 if db_user.endswith("_qs") else 10),
                 )
+            )
 
             # Make sure we don't keep the roles in the current user (we don't need them, and
             # the master user having a lot of roles can slow login)


### PR DESCRIPTION
### Description of change

This removes setting settings on permanent roles when creating credentials. Now the settings are only done on the temporary user used to login. This should not have any effect because, from https://www.postgresql.org/docs/14/sql-alterrole.html
    
> executing SET ROLE or SET SESSION AUTHORIZATION does not cause new configuration values to be set.
    
and from https://www.postgresql.org/docs/14/view-pg-roles.html about the connect limit specifically
    
> For roles that can log in, this sets maximum number of concurrent connections this role can make.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?