### PR TITLE
perf: faster database tab (and better exclude non-tables)

### DIFF
--- a/dataworkspace/dataworkspace/tests/explorer/test_schema.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_schema.py
@@ -4,7 +4,17 @@ import pytest
 from django.conf import settings
 from django.core.cache import cache
 
+from dataworkspace.apps.core.models import (
+    Database,
+)
 from dataworkspace.apps.explorer import schema
+from dataworkspace.apps.datasets.constants import (
+    UserAccessType,
+)
+from dataworkspace.tests.factories import (
+    MasterDataSetFactory,
+    SourceTableFactory,
+)
 
 
 class TestSchemaInfo:
@@ -13,26 +23,33 @@ class TestSchemaInfo:
         cache.clear()
 
     @staticmethod
-    def _get_connection_data():
-        connection_info = settings.DATABASES_DATA["my_database"]
+    def _setup_source_dataset():
+        # Sets up a source dataset with tables that already exist in the database,
+        # making it convenient for testing
+        database = Database.objects.get(memorable_name="my_database")
+        dataset = MasterDataSetFactory(
+            user_access_type=UserAccessType.REQUIRES_AUTHENTICATION,
+            published=True,
+        )
+        SourceTableFactory(
+            database=database,
+            dataset=dataset,
+            schema="public",
+            table="auth_user",
+        )
+        SourceTableFactory(
+            database=database,
+            dataset=dataset,
+            schema="public",
+            table="explorer_query",
+        )
 
-        return {
-            "db_host": connection_info["HOST"],
-            "db_port": connection_info["PORT"],
-            "db_user": connection_info["USER"],
-            "db_password": connection_info["PASSWORD"],
-            "db_name": connection_info["NAME"],
-        }
-
-    @patch("dataworkspace.apps.explorer.schema.get_user_explorer_connection_settings")
     @patch("dataworkspace.apps.explorer.schema._get_includes")
     @patch("dataworkspace.apps.explorer.schema._get_excludes")
-    def test_schema_info_returns_valid_data(
-        self, mocked_excludes, mocked_includes, mock_connection_settings, staff_user
-    ):
+    def test_schema_info_returns_valid_data(self, mocked_excludes, mocked_includes, staff_user):
+        self._setup_source_dataset()
         mocked_includes.return_value = None
         mocked_excludes.return_value = []
-        mock_connection_settings.return_value = self._get_connection_data()
         res = schema.schema_info(staff_user, settings.EXPLORER_CONNECTIONS["Postgres"])
         assert mocked_includes.called  # sanity check: ensure patch worked
         tables = [x.name.name for x in res]
@@ -40,43 +57,34 @@ class TestSchemaInfo:
         schemas = [x.name.schema for x in res]
         assert "public" in schemas
 
-    @patch("dataworkspace.apps.explorer.schema.get_user_explorer_connection_settings")
     @patch("dataworkspace.apps.explorer.schema._get_includes")
     @patch("dataworkspace.apps.explorer.schema._get_excludes")
-    def test_table_exclusion_list(
-        self, mocked_excludes, mocked_includes, mock_connection_settings, staff_user
-    ):
+    def test_table_exclusion_list(self, mocked_excludes, mocked_includes, staff_user):
+        self._setup_source_dataset()
         mocked_includes.return_value = None
         mocked_excludes.return_value = ("explorer_",)
-        mock_connection_settings.return_value = self._get_connection_data()
         res = schema.schema_info(staff_user, settings.EXPLORER_CONNECTIONS["Postgres"])
         tables = [x.name.name for x in res]
         assert "explorer_query" not in tables
 
-    @patch("dataworkspace.apps.explorer.schema.get_user_explorer_connection_settings")
     @patch("dataworkspace.apps.explorer.schema._get_includes")
     @patch("dataworkspace.apps.explorer.schema._get_excludes")
-    def test_app_inclusion_list(
-        self, mocked_excludes, mocked_includes, mock_connection_settings, staff_user
-    ):
+    def test_app_inclusion_list(self, mocked_excludes, mocked_includes, staff_user):
+        self._setup_source_dataset()
         mocked_includes.return_value = ("auth_",)
         mocked_excludes.return_value = []
-        mock_connection_settings.return_value = self._get_connection_data()
         res = schema.schema_info(staff_user, settings.EXPLORER_CONNECTIONS["Postgres"])
         tables = [x.name.name for x in res]
         assert "explorer_query" not in tables
         assert "auth_user" in tables
 
-    @patch("dataworkspace.apps.explorer.schema.get_user_explorer_connection_settings")
     @patch("dataworkspace.apps.explorer.schema._get_includes")
     @patch("dataworkspace.apps.explorer.schema._get_excludes")
-    def test_app_inclusion_list_excluded(
-        self, mocked_excludes, mocked_includes, mock_connection_settings, staff_user
-    ):
+    def test_app_inclusion_list_excluded(self, mocked_excludes, mocked_includes, staff_user):
+        self._setup_source_dataset()
         # Inclusion list "wins"
         mocked_includes.return_value = ("explorer_",)
         mocked_excludes.return_value = ("explorer_",)
-        mock_connection_settings.return_value = self._get_connection_data()
         res = schema.schema_info(staff_user, settings.EXPLORER_CONNECTIONS["Postgres"])
         tables = [x.name.name for x in res]
         assert "explorer_query" in tables


### PR DESCRIPTION
### Description of change

The Database tab in Data Explorer can be quite slow. It's cached, and uses Ajax on a separate tab to not block the main page load, but it's still not great. By using PostgreSQL catalogue tables even more directly by leveraging pg_shdepend we can speed it up

At busy database times, the previous query took around 45 seconds, and the new around 1 second. At less busy times the difference is less pronounced, the previous query taking ~2 seconds and the new around 0.75 seconds.

As a small bonus, this now properly excludes indexes and sequences by using the 'relkind' field when filtering on pg_class.

The change in the tests is because the previous way automatically included tables granted to the PUBLIC role - the new way doesn't and the user has to have permissions granted explicitly for them to appear.  However, because in production we do explicitly grant permissions via catalogue pages, even to things in the public schema, this makes the new way a touch more similar to what happens in production.


### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?