### PR TITLE
feat/DT-2010: Add endpoint for inline feedback

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v2/inline_feedback/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v2/inline_feedback/serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+from dataworkspace.apps.core.models import UserInlineFeedbackSurvey
+
+
+class FeedbackSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = UserInlineFeedbackSurvey
+        fields = [
+            "id",
+            "location",
+            "was_this_page_helpful",
+            "inline_feedback_choices",
+            "more_detail",
+        ]

--- a/dataworkspace/dataworkspace/apps/api_v2/inline_feedback/urls.py
+++ b/dataworkspace/dataworkspace/apps/api_v2/inline_feedback/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+from dataworkspace.apps.api_v2.inline_feedback import views
+
+urlpatterns = [
+    path(
+        "inline_feedback", views.InlineFeedBackViewSet.as_view({"post": "create"}), name="create"
+    ),
+    path(
+        "inline_feedback/<int:pk>",
+        views.InlineFeedBackViewSet.as_view({"patch": "partial_update"}),
+        name="update",
+    ),
+]

--- a/dataworkspace/dataworkspace/apps/api_v2/inline_feedback/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v2/inline_feedback/views.py
@@ -1,0 +1,29 @@
+from rest_framework import status, mixins
+from rest_framework.viewsets import GenericViewSet
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from dataworkspace.apps.core.models import UserInlineFeedbackSurvey
+from .serializers import FeedbackSerializer
+
+
+class InlineFeedBackViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, GenericViewSet):
+    queryset = UserInlineFeedbackSurvey.objects.all()
+    serializer_class = FeedbackSerializer
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def perform_create(self, serializer):
+        location = serializer.validated_data.get("location")
+        was_this_page_helpful = serializer.validated_data.get("was_this_page_helpful")
+        serializer.save(was_this_page_helpful=was_this_page_helpful)
+        serializer.save(location=location)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def perform_update(self, serializer):
+        inline_feedback_choices = serializer.validated_data.get("inline_feedback_choices")
+        more_detail = serializer.validated_data.get("more_detail")
+        serializer.save(inline_feedback_choices=inline_feedback_choices)
+        serializer.save(more_detail=more_detail)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/dataworkspace/dataworkspace/apps/api_v2/urls.py
+++ b/dataworkspace/dataworkspace/apps/api_v2/urls.py
@@ -26,4 +26,11 @@ urlpatterns = [
             ("dataworkspace.apps.api_v2.recent_tools.urls", "api_v2"), namespace="recent_tools"
         ),
     ),
+    path(
+        "",
+        include(
+            ("dataworkspace.apps.api_v2.inline_feedback.urls", "api_v2"),
+            namespace="inline_feedback",
+        ),
+    ),
 ]

--- a/dataworkspace/dataworkspace/tests/api_v2/inline_feedback/test_inline_feedback_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v2/inline_feedback/test_inline_feedback_views.py
@@ -1,0 +1,48 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from dataworkspace.tests import factories
+
+
+@pytest.mark.django_db
+def test_unauthenticated_inline_feedback(unauthenticated_client):
+    response = unauthenticated_client.get(reverse("api-v2:inline_feedback:create"))
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_creating_inline_feedback(client, user):
+    client.force_login(user)
+    response = client.post(
+        reverse("api-v2:inline_feedback:create"),
+        {"location": "some location", "was_this_page_helpful": "true"},
+        follow=True,
+    )
+    assert response.json() == {
+        "id": 1,
+        "location": "some location",
+        "was_this_page_helpful": True,
+        "inline_feedback_choices": None,
+        "more_detail": None,
+    }
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.django_db
+def test_updating_inline_feedback(client, user):
+    client.force_login(user)
+    feedback = factories.InlineFeedbackFactory.create()
+    response = client.patch(
+        reverse("api-v2:inline_feedback:update", args=f"{feedback.id}"),
+        data={"inline_feedback_choices": "awesome", "more_detail": "blah blah"},
+        content_type="application/json",
+    )
+    assert response.json() == {
+        "id": feedback.id,
+        "location": feedback.location,
+        "was_this_page_helpful": True,
+        "inline_feedback_choices": "awesome",
+        "more_detail": "blah blah",
+    }
+    assert response.status_code == status.HTTP_200_OK

--- a/dataworkspace/dataworkspace/tests/factories.py
+++ b/dataworkspace/dataworkspace/tests/factories.py
@@ -482,3 +482,13 @@ class UserDataTableViewFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = "accounts.UserDataTableView"
+
+
+class InlineFeedbackFactory(factory.django.DjangoModelFactory):
+    was_this_page_helpful = True
+    location = factory.fuzzy.FuzzyText()
+    inline_feedback_choices = ""
+    more_detail = ""
+
+    class Meta:
+        model = "core.UserInlineFeedbackSurvey"


### PR DESCRIPTION
### Description of change
This change adds a REST endpoint which allows the client to add inline feedback data to the database. 

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?