### PR TITLE
Added page for self certify

### DIFF
--- a/dataworkspace/dataworkspace/apps/request_access/forms.py
+++ b/dataworkspace/dataworkspace/apps/request_access/forms.py
@@ -4,14 +4,18 @@ from django.template.loader import render_to_string
 from dataworkspace.apps.request_access.models import AccessRequest
 from dataworkspace.forms import (
     GOVUKDesignSystemBooleanField,
+    GOVUKDesignSystemDateField,
+    GOVUKDesignSystemForm,
     GOVUKDesignSystemModelForm,
     GOVUKDesignSystemRadiosWidget,
     GOVUKDesignSystemCharField,
+    GOVUKDesignSystemSingleCheckboxWidget,
     GOVUKDesignSystemTextareaField,
     GOVUKDesignSystemTextareaWidget,
     GOVUKDesignSystemTextWidget,
     GOVUKDesignSystemFileField,
     GOVUKDesignSystemFileInputWidget,
+    GOVUKDesignSystemDateWidget,
 )
 
 
@@ -110,4 +114,38 @@ class ToolsAccessRequestFormPart3(GOVUKDesignSystemModelForm):
             attrs={"rows": 5},
         ),
         error_messages={"required": "Enter a reason for needing STATA."},
+    )
+
+
+class SelfCertifyForm(GOVUKDesignSystemForm):
+    certificate_date = GOVUKDesignSystemDateField(
+        label="Enter the date that's on your certificate?",
+        help_text="For example, 27 3 2007",
+        widget=GOVUKDesignSystemDateWidget(
+            day_attrs={
+                "label": "Day",
+                "label_is_heading": False,
+                "inputmode": "numeric",
+                "extra_input_classes": "govuk-date-input__input govuk-input--width-2",
+            },
+            month_attrs={
+                "label": "Month",
+                "label_is_heading": False,
+                "inputmode": "numeric",
+                "extra_input_classes": "govuk-date-input__input govuk-input--width-2",
+            },
+            year_attrs={
+                "label": "Year",
+                "label_is_heading": False,
+                "inputmode": "numeric",
+                "extra_input_classes": "govuk-date-input__input govuk-input--width-4",
+            },
+        ),
+    )
+
+    declaration = GOVUKDesignSystemBooleanField(
+        label="I confirm that I've completed the Security and Data Protection training and the date I've entered matches my certificate.",  # pylint: disable=line-too-long
+        widget=GOVUKDesignSystemSingleCheckboxWidget(
+            label_is_heading=False, extra_label_classes="govuk-!-font-weight-bold"
+        ),
     )

--- a/dataworkspace/dataworkspace/apps/request_access/urls.py
+++ b/dataworkspace/dataworkspace/apps/request_access/urls.py
@@ -6,6 +6,7 @@ from dataworkspace.apps.request_access.views import (
     AccessRequestSummaryPage,
     DatasetAccessRequest,
     DatasetAccessRequestUpdate,
+    SelfCertifyView,
     ToolsAccessRequestPart1,
     ToolsAccessRequestPart2,
     ToolsAccessRequestPart3,
@@ -51,5 +52,10 @@ urlpatterns = [
         "<int:pk>/confirmation",
         login_required(AccessRequestConfirmationPage.as_view()),
         name="confirmation-page",
+    ),
+    path(
+        "self-certify",
+        login_required(SelfCertifyView.as_view()),
+        name="self-certify-page",
     ),
 ]

--- a/dataworkspace/dataworkspace/apps/request_access/views.py
+++ b/dataworkspace/dataworkspace/apps/request_access/views.py
@@ -2,7 +2,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render
 from django.urls import reverse, resolve
-from django.views.generic import CreateView, UpdateView, DetailView
+from django.views.generic import CreateView, UpdateView, DetailView, FormView
 
 from dataworkspace.apps.applications.models import ApplicationInstance
 from dataworkspace.apps.datasets.constants import DataSetType
@@ -12,6 +12,7 @@ from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.apps.eventlog.utils import log_event
 from dataworkspace.apps.request_access.forms import (  # pylint: disable=import-error
     DatasetAccessRequestForm,
+    SelfCertifyForm,
     ToolsAccessRequestFormPart1,
     ToolsAccessRequestFormPart2,
     ToolsAccessRequestFormPart3,
@@ -246,3 +247,20 @@ class AccessRequestConfirmationPage(RequestAccessMixin, DetailView):
             else None
         )
         return context
+
+
+class SelfCertifyView(FormView):
+    form_class = SelfCertifyForm
+    template_name = "request_access/self-certify.html"
+
+    def get(self, request, *args, **kwargs):
+        # TODO add the check here that the user email domain is allowed, otherwise send them to # pylint: disable=fixme
+        # the page where they must upload docs https://uktrade.atlassian.net/browse/DT-2032
+        is_user_allowed_to_use_self_certify = True
+        if not is_user_allowed_to_use_self_certify:
+            return HttpResponseRedirect(reverse("request-access:index"))
+        return super().get(request, args, kwargs)
+
+    def form_valid(self, form):
+        # TODO add the logic here to store the certification value against the user # pylint: disable=fixme
+        return HttpResponseRedirect("/tools")  # pylint: disable=fixme

--- a/dataworkspace/dataworkspace/templates/design_system/date.html
+++ b/dataworkspace/dataworkspace/templates/design_system/date.html
@@ -1,0 +1,34 @@
+{% with id=widget.attrs.id %}
+
+<div class="govuk-form-group {% if widget.errors %}govuk-form-group--error{% endif %}">
+  <fieldset class="govuk-fieldset" role="group" aria-describedby="{{ id }}-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h2 class="govuk-heading-m">
+        {{widget.label}}
+      </h2>
+    </legend>
+    {% if widget.help_html %}
+      <div id="{{ id }}-hint">
+        {{ widget.help_html }}
+      </div>
+      {% elif widget.help_text %}
+      <div id="{{ id }}-hint" class="govuk-hint">
+        {{ widget.help_text }}
+      </div>
+    {% endif %}
+    {% if widget.errors %}
+      <span id="{{ id }}-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error: </span>{{ widget.errors.0 }}
+      </span>
+    {% endif %}
+    <div class="govuk-date-input" id="{{ id }}">
+      {% for subwidget in widget.subwidgets %}  
+        {{ subwidget }}
+          <div class="govuk-date-input__item">
+            {% include subwidget.template_name with widget=subwidget %}
+          </div>        
+      {% endfor %}
+    </div>
+  </fieldset>
+</div>
+{% endwith %}

--- a/dataworkspace/dataworkspace/templates/design_system/textinput.html
+++ b/dataworkspace/dataworkspace/templates/design_system/textinput.html
@@ -27,7 +27,7 @@
   {% endif %}
 
   <input
-          class="govuk-input"
+          class="govuk-input {{ widget.extra_input_classes }}"
           type="text"
           name="{{ widget.name }}"
           {% if widget.help_text %}aria-describedby="{{ id }}-hint" {% endif %}

--- a/dataworkspace/dataworkspace/templates/request_access/self-certify.html
+++ b/dataworkspace/dataworkspace/templates/request_access/self-certify.html
@@ -1,0 +1,55 @@
+{% extends '_main.html' %}DBT
+
+{% block page_title %}Get access to tools{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="govuk-breadcrumbs">
+        <ol class="govuk-breadcrumbs__list">
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link" href="/">Home</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">Get access
+            </li>
+        </ol>
+    </div>
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {% include 'design_system/error_summary.html' with form=form %}
+            <h1 class="govuk-heading-xl">Get access to tools</h1>
+
+            <p class="govuk-body">
+              To get access to tools you need to have completed the <a href="https://www.learninghub.businessandtrade.gov.uk/group/guest/learning-paths" class="govuk-link" target="_blank">Security and Data Protection</a> training. It's mandatory for all DBT staff and needs to be completed every 12 months.
+            </p>
+            <p class="govuk-body">
+              <span>Once you have verified your training is up to date, you will get access to:</span>
+            </p>
+
+            <ul class="govuk-list govuk-list--bullet">
+                <li>Quicksight</li>
+                <li>pgAdmin</li>
+                <li>Data Explorer</li>
+                <li>RStudio</li>
+                <li>JupyterLab Python</li>
+                <li>Theia</li>
+                <li>Your Files</li>
+            </ul>
+
+            <h2 class="govuk-heading-l">How to verify your training is up to date</h2>
+            <p class="govuk-body">
+              You need to give us the date that's on your Security and Data Protection certificate by entering it into the boxes below.
+            </p>
+            <form method="post">
+              {% csrf_token %}
+              {{ form.certificate_date }}
+              <span class="govuk-label  govuk-!-font-weight-bold">
+                Declaration
+              </span>
+              {{ form.declaration }}
+              <button type="submit" class="govuk-button">Submit</button>
+            </form>            
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
### Description of change
Adds a new page at the `request-access/self-certify` url to allow users to self submit proof they are allowed to access tools.

This PR does not add any logic to save the values in the form, it is just the content with redirects 

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?