### PR TITLE
Update request access to get access for tools page

### DIFF
--- a/dataworkspace/dataworkspace/templates/partials/tool_section.html
+++ b/dataworkspace/dataworkspace/templates/partials/tool_section.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="govuk-grid-column-one-half">
-    {% if not false %}
+    {% if not has_access %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half"><p class="govuk-body"></p></div>
         <div class="govuk-grid-column-one-half">

--- a/dataworkspace/dataworkspace/templates/partials/tool_section.html
+++ b/dataworkspace/dataworkspace/templates/partials/tool_section.html
@@ -15,11 +15,11 @@
   </div>
 
   <div class="govuk-grid-column-one-half">
-    {% if not has_access %}
+    {% if not false %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half"><p class="govuk-body"></p></div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-button govuk-button--secondary" href="{% url 'request_access:index' %}">Request access to {{ application_name }}</a>
+          <a class="govuk-button govuk-button--secondary" href="{% url 'request_access:index' %}">Get access to {{ application_name }}</a>
         </div>
       </div>
     {% elif instance %}

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -301,7 +301,7 @@ def test_footer_links(request_client):
         (
             False,
             "/request-access/",
-            "Request access to QuickSight",
+            "Get access to QuickSight",
         ),
     ),
 )
@@ -333,7 +333,7 @@ def test_quicksight_link_only_shown_to_user_with_permission(
         (
             False,
             "/request-access/",
-            "Request access to STATA",
+            "Get access to STATA",
         ),
     ),
 )


### PR DESCRIPTION
### Description of change
When user does not have access to tool(s) on the tools page, the button now says `Get access to {tool}` instead of `request access to {tool}`

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?