### PR TITLE
Filter for 'Data I am an editor for'

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -156,6 +156,7 @@ class DatasetSearchForm(forms.Form):
     BOOKMARKED = "bookmarked"
     OWNED = "owned"
     CONTACT = "enquiries_contact"
+    EDITOR = "editor"
 
     q = forms.CharField(required=False)
 
@@ -185,6 +186,7 @@ class DatasetSearchForm(forms.Form):
             (SUBSCRIBED, "My subscriptions"),
             (OWNED, "Data I own or manage"),
             (CONTACT, "Data I am a contact for"),
+            (EDITOR, "Data I am an editor for"),
         ],
         required=False,
         widget=AccordionFilterWidget("My datasets"),

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -200,6 +200,8 @@ def _get_datasets_data_for_user_matching_query(
 
     datasets = _annotate_is_contact(datasets, user)
 
+    datasets = _annotate_is_editor(datasets, user)
+
     return datasets.values(
         id_field,
         "name",
@@ -225,6 +227,7 @@ def _get_datasets_data_for_user_matching_query(
         "average_unique_users_daily",
         "is_owner",
         "is_contact",
+        "is_editor",
     )
 
 
@@ -535,7 +538,7 @@ def _annotate_has_access(datasets, user):
 def _annotate_is_contact(datasets, user):
     """
     Adds a boolean annotation to queryset which is set to True if the user
-    is an IAO, IAM or data catalogue editor of a dataset
+    is an enquiries contact of a dataset
     @param datasets: Django queryset
     @param user: request.user
     @return: Annotated queryset
@@ -546,6 +549,30 @@ def _annotate_is_contact(datasets, user):
             Case(
                 When(
                     Q(enquiries_contact=user),
+                    then=True,
+                ),
+                default=False,
+                output_field=BooleanField(),
+            ),
+        ),
+    )
+    return datasets
+
+
+def _annotate_is_editor(datasets, user):
+    """
+    Adds a boolean annotation to queryset which is set to True if the user
+    is a data catalogue editor of a dataset
+    @param datasets: Django queryset
+    @param user: request.user
+    @return: Annotated queryset
+    """
+
+    datasets = datasets.annotate(
+        is_editor=BoolOr(
+            Case(
+                When(
+                    Q(data_catalogue_editors=user),
                     then=True,
                 ),
                 default=False,
@@ -601,8 +628,6 @@ def _sorted_datasets_and_visualisations_matching_query_for_user(query, user, sor
         id_field="id",
         user=user,
     )
-
-    print("result", master_and_datacut_datasets)
 
     reference_datasets = _get_datasets_data_for_user_matching_query(
         ReferenceDataset.objects.live().annotate(

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -586,7 +586,7 @@ def _annotate_is_editor(datasets, user):
 def _annotate_is_owner(datasets, user):
     """
     Adds a boolean annotation to queryset which is set to True if the user
-    is an IAO, IAM or data catalogue editor of a dataset
+    is an IAO or IAM of a dataset
     @param datasets: Django queryset
     @param user: request.user
     @return: Annotated queryset
@@ -596,9 +596,7 @@ def _annotate_is_owner(datasets, user):
         is_owner=BoolOr(
             Case(
                 When(
-                    Q(information_asset_owner=user)
-                    | Q(information_asset_manager=user)
-                    | Q(data_catalogue_editors=user),
+                    Q(information_asset_owner=user) | Q(information_asset_manager=user),
                     then=True,
                 ),
                 default=False,

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -143,6 +143,8 @@ def _matches_filters(
         users_datasets.add("owned")
     if data["is_contact"]:
         users_datasets.add("enquiries_contact")
+    if data["is_editor"]:
+        users_datasets.add("editor")
 
     return (
         (

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -271,6 +271,7 @@ def expected_search_result(catalogue_item, **kwargs):
         "average_unique_users_daily": mock.ANY,
         "is_owner": False,
         "is_contact": False,
+        "is_editor": False,
     }
     result.update(**kwargs)
     return result
@@ -1316,6 +1317,27 @@ def test_find_datasets_filters_by_enquires_contact(user, client):
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [
         expected_search_result(ds1, is_contact=True),
+        expected_search_result(ds2),
+        expected_search_result(ds3),
+    ]
+
+
+@pytest.mark.django_db
+def test_find_datasets_filters_by_editor(user, client):
+    ds1 = factories.DataSetFactory.create(
+        name="Dataset",
+        user_access_type=UserAccessType.REQUIRES_AUTHENTICATION,
+    )
+    ds1.data_catalogue_editors.set([user])
+    ds2 = factories.ReferenceDatasetFactory.create(name="Reference")
+    ds3 = factories.VisualisationCatalogueItemFactory.create(
+        name="Visualisation", user_access_type=UserAccessType.REQUIRES_AUTHENTICATION
+    )
+
+    response = client.get(reverse("datasets:find_datasets"))
+    assert response.status_code == 200
+    assert list(response.context["datasets"]) == [
+        expected_search_result(ds1, is_editor=True),
         expected_search_result(ds2),
         expected_search_result(ds3),
     ]

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1328,7 +1328,8 @@ def test_find_datasets_filters_by_editor(user, client):
         name="Dataset",
         user_access_type=UserAccessType.REQUIRES_AUTHENTICATION,
     )
-    ds1.data_catalogue_editors.set([user])
+    ds1.data_catalogue_editors.add(user)
+
     ds2 = factories.ReferenceDatasetFactory.create(name="Reference")
     ds3 = factories.VisualisationCatalogueItemFactory.create(
         name="Visualisation", user_access_type=UserAccessType.REQUIRES_AUTHENTICATION


### PR DESCRIPTION
### Description of change
When a user is a `data_catalogue_editor` of a dataset it should appear under the new filter `Data I am an editor for`. It currently appears under the `Data I own or manage` filter.

### Screenshots
![Screenshot 2024-06-10 at 10 09 35](https://github.com/uktrade/data-workspace-frontend/assets/54268863/120945c1-c844-4ab5-8e56-9824f33dc4bf)

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?