### PR TITLE
Feat/dt-2036 update error messages

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/constants.py
+++ b/dataworkspace/dataworkspace/apps/core/constants.py
@@ -25,8 +25,14 @@ TABLESCHEMA_FIELD_TYPE_MAP = {
 }
 
 DATA_FLOW_TASK_ERROR_MAP = {
-    r".*Unable to decode CSV as.*|.*UnicodeDecodeError.*": "core/partial/errors/decode.html",
-    r".*invalid input syntax for (type )?(numeric|integer).*": "core/partial/errors/input-syntax.html",
-    r".*NumericValueOutOfRange.*": "core/partial/errors/out-of-range.html",
-    r".*DatetimeFieldOverflow.*|.*InvalidDatetimeFormat*": "core/partial/errors/invalid-date.html",
+    r".*is of type bigint but expression is of type boolean.*": "core/partial/errors/setting-boolean-integer.html",
+    r".*is of type numeric but expression is of type boolean.*": "core/partial/errors/setting-boolean-numeric.html",
+    r".*is of type date but expression is of type boolean.*": "core/partial/errors/setting-boolean-date.html",
+    r".*is of type timestamp with time zone but expression is of type boolean.*": "core/partial/errors/setting-boolean-datetime.html",  # pylint: disable=line-too-long
+    r".*Not a boolean value*.": "core/partial/errors/setting-value-as-boolean.html",
+    r".*invalid input syntax for type bigint.*": "core/partial/errors/setting-string-integer.html",
+    r".*invalid input syntax for type numeric.*": "core/partial/errors/setting-string-numeric.html",
+    r".*is of type date.*|.*invalid input syntax for type date*.": "core/partial/errors/setting-value-as-date.html",
+    r".*is of type timestamp.*|.*invalid input syntax for type timestamp*.": "core/partial/errors/setting-value-as-datetime.html",  # pylint: disable=line-too-long
+    r".*date/time field value out of range.*": "core/partial/errors/setting-date-as-incorrect-date.html",
 }

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/decode.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/decode.html
@@ -1,6 +1,0 @@
-<p class="govuk-body">
-  Your file, {{ filename }}, cannot be processed due to a character encoding error.
-</p>
-<p class="govuk-body">
- If this problem persists, <a class="govuk-link" href="{% url 'support' %}">contact the Data Workspace Team</a> for help.
-</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/input-syntax.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/input-syntax.html
@@ -1,6 +1,0 @@
-<p class="govuk-body">
-  Your file, {{ filename }}, cannot be processed due to an error parsing a numeric field.
-</p>
-<p class="govuk-body">
- This can occur when a column's data type is set as numeric or integer and the column in the csv contains characters.
-</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/invalid-date.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/invalid-date.html
@@ -1,6 +1,0 @@
-<p class="govuk-body">
-  Your file, {{ filename }}, cannot be processed due to an error parsing a date field. This can occur when a date column is in US format.
-</p>
-<p class="govuk-body">
- The recommended date format for data workspace uploads is <nobr>YYYY-MM-DD</nobr>.
-</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/out-of-range.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/out-of-range.html
@@ -1,6 +1,0 @@
-<p class="govuk-body">
-  Your file, {{ filename }}, cannot be processed due to an out of range error.
-</p>
-<p class="govuk-body">
- This can occur when a column with a data type set to integer contains numbers with more than 12 digits.
-</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-date.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-date.html
@@ -7,5 +7,5 @@
 <p class="govuk-body">Check all columns set as 'Date' and make sure the data in these columns has an appropriate data type.</p>
 <p class="govuk-body">Once you’ve fixed the error, <a
         href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
-        class="govuk-link">re-upload your file.</a>
+        class="govuk-link">re-upload your file</a>.
 </p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-date.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-date.html
@@ -1,0 +1,11 @@
+<h1 class="govuk-heading-xl">
+    There's an error in a column which has been set as: 'Date'
+</h1>
+
+<p class="govuk-body">Your table has not been added.</p>
+<p class="govuk-body">Data Workspace has identified boolean values in a column set as 'Date'.</p>
+<p class="govuk-body">Check all columns set as 'Date' and make sure the data in these columns has an appropriate data type.</p>
+<p class="govuk-body">Once you’ve fixed the error, <a
+        href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
+        class="govuk-link">re-upload your file.</a>
+</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-datetime.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-datetime.html
@@ -4,8 +4,8 @@
 
 <p class="govuk-body">Your table has not been added.</p>
 <p class="govuk-body">Data Workspace has identified boolean values in a column set as 'Datetime'.</p>
-<p class="govuk-body">Check all columns set as 'Date' and make sure the data in these columns has an appropriate data type.</p>
+<p class="govuk-body">Check all columns set as 'Datetime' and make sure the data in these columns has an appropriate data type.</p>
 <p class="govuk-body">Once you’ve fixed the error, <a
         href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
-        class="govuk-link">re-upload your file.</a>
+        class="govuk-link">re-upload your file</a>.
 </p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-datetime.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-datetime.html
@@ -1,0 +1,11 @@
+<h1 class="govuk-heading-xl">
+    There's an error in a column which has been set as: 'Datetime'
+</h1>
+
+<p class="govuk-body">Your table has not been added.</p>
+<p class="govuk-body">Data Workspace has identified boolean values in a column set as 'Datetime'.</p>
+<p class="govuk-body">Check all columns set as 'Date' and make sure the data in these columns has an appropriate data type.</p>
+<p class="govuk-body">Once you’ve fixed the error, <a
+        href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
+        class="govuk-link">re-upload your file.</a>
+</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-integer.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-integer.html
@@ -1,0 +1,12 @@
+<h1 class="govuk-heading-xl">
+    There's an error in a column which has been set as: 'Integer'
+</h1>
+
+<p class="govuk-body">Your table has not been added.</p>
+<p class="govuk-body">Data Workspace has identified boolean values in a column set as 'Integer'.</p>
+<p class="govuk-body">Integers are: whole numbers and have 12 digits or less. <br> Booleans are: one of three possible values - true, false, or null.</p>
+<p class="govuk-body">Check all columns set as 'Integer' and make sure the data in these columns has an appropriate data type.</p>
+<p class="govuk-body">Once you’ve fixed the error, <a
+        href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
+        class="govuk-link">re-upload your file.</a>
+</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-integer.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-integer.html
@@ -8,5 +8,5 @@
 <p class="govuk-body">Check all columns set as 'Integer' and make sure the data in these columns has an appropriate data type.</p>
 <p class="govuk-body">Once you’ve fixed the error, <a
         href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
-        class="govuk-link">re-upload your file.</a>
+        class="govuk-link">re-upload your file</a>.
 </p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-numeric.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-numeric.html
@@ -8,5 +8,5 @@
 <p class="govuk-body">Check all columns set as 'Numeric' and make sure the data in these columns has an appropriate data type.</p>
 <p class="govuk-body">Once you’ve fixed the error, <a
         href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
-        class="govuk-link">re-upload your file.</a>
+        class="govuk-link">re-upload your file</a>.
 </p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-numeric.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-boolean-numeric.html
@@ -1,0 +1,12 @@
+<h1 class="govuk-heading-xl">
+    There's an error in a column which has been set as: 'Numeric'
+</h1>
+
+<p class="govuk-body">Your table has not been added.</p>
+<p class="govuk-body">Data Workspace has identified boolean values in a column set as 'Numeric'.</p>
+<p class="govuk-body">Numerics are: numbers with more than 12 digits and can have decimals. <br> Booleans are: one of three values - true, false, or null.</p>
+<p class="govuk-body">Check all columns set as 'Numeric' and make sure the data in these columns has an appropriate data type.</p>
+<p class="govuk-body">Once you’ve fixed the error, <a
+        href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
+        class="govuk-link">re-upload your file.</a>
+</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-date-as-incorrect-date.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-date-as-incorrect-date.html
@@ -1,0 +1,16 @@
+<h1 class="govuk-heading-xl">
+    Your CSV contains a date that cannot be correct
+</h1>
+
+<p class="govuk-body">Your table has not been added.</p>
+<p class="govuk-body">This usually means you have a value in a 'Date' or 'Datetime' column which is impossible. For example, 2021-90-01.</p>
+<p class="govuk-body">Check all columns set as 'Date' or 'Datetime' data types:</p>
+ <ul class="govuk-list govuk-list--bullet">
+    <li> <a href="https://support.microsoft.com/en-gb/office/change-the-format-of-a-cell-0a45ff85-ee24-4276-94e8-aed6083e8050#:~:text=Select%20the%20cells%20with%20the,to%20change%20what%20you%20want." class="govuk-link">are formatted as yyyy-mm-dd in Excel</a></li>
+    <li>are real dates</li>
+    <li>only contain dates (for example, check you have not set 'Numeric' data as 'Date' or 'Datetime')</li>
+ </ul>
+<p class="govuk-body">Once you’ve fixed the error, <a
+        href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
+        class="govuk-link">re-upload your file.</a>
+</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-date-as-incorrect-date.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-date-as-incorrect-date.html
@@ -12,5 +12,5 @@
  </ul>
 <p class="govuk-body">Once you’ve fixed the error, <a
         href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
-        class="govuk-link">re-upload your file.</a>
+        class="govuk-link">re-upload your file</a>.
 </p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-string-integer.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-string-integer.html
@@ -1,0 +1,17 @@
+<h1 class="govuk-heading-xl">
+    Your CSV contains a 'String' value that cannot be set as 'Integer'
+</h1>
+<p class="govuk-body">Your table has not been added.</p>
+
+<p class="govuk-body">String values are used for text, integers are used for numbers up to 12 digits.</p>
+
+<p class="govuk-body">You need to check all columns set as 'Integer' data type and fix the error.</p>
+<p class="govuk-body">Once you’ve fixed the error, <a
+        href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
+        class="govuk-link">re-upload your file.</a>
+</p>
+
+<div class="govuk-inset-text">
+    Check columns set as integer do not have any 'Date' values. This can also cause this error.
+</div>
+

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-string-integer.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-string-integer.html
@@ -8,7 +8,7 @@
 <p class="govuk-body">You need to check all columns set as 'Integer' data type and fix the error.</p>
 <p class="govuk-body">Once you’ve fixed the error, <a
         href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
-        class="govuk-link">re-upload your file.</a>
+        class="govuk-link">re-upload your file</a>.
 </p>
 
 <div class="govuk-inset-text">

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-string-numeric.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-string-numeric.html
@@ -11,5 +11,5 @@
 </p>
 
 <div class="govuk-inset-text">
-    Check columns set as integer do not have any 'Date' values. This can also cause this error.
+    Check columns set as numeric do not have any 'Date' values. This can also cause this error.
 </div>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-string-numeric.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-string-numeric.html
@@ -1,0 +1,13 @@
+<h1 class="govuk-heading-xl">
+    Your CSV contains a 'String' value that cannot be set as 'Numeric'
+</h1>
+<p class="govuk-body">Your table has not been added.</p>
+
+<p class="govuk-body">String values are used for text, 'Numeric' are used for numbers up to 12 digits.</p>
+<p class="govuk-body">You need to check all columns set as 'Numeric' data type and fix the error.</p> 
+<p class="govuk-body">Once you’ve fixed the error, <a href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}" class="govuk-link">re-upload your file.</a>
+</p>
+
+<div class="govuk-inset-text">
+    Check columns set as integer do not have any 'Date' values. This can also cause this error.
+</div>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-string-numeric.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-string-numeric.html
@@ -3,9 +3,11 @@
 </h1>
 <p class="govuk-body">Your table has not been added.</p>
 
-<p class="govuk-body">String values are used for text, 'Numeric' are used for numbers up to 12 digits.</p>
+<p class="govuk-body">String values are used for text, 'Numeric' are used for numbers with decimals.</p>
 <p class="govuk-body">You need to check all columns set as 'Numeric' data type and fix the error.</p> 
-<p class="govuk-body">Once you’ve fixed the error, <a href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}" class="govuk-link">re-upload your file.</a>
+<p class="govuk-body">Once you’ve fixed the error, <a
+        href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
+        class="govuk-link">re-upload your file</a>.
 </p>
 
 <div class="govuk-inset-text">

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-boolean.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-boolean.html
@@ -7,5 +7,5 @@
 <p class="govuk-body">You need to check all columns set as 'Boolean' data type and fix the error.</p>
 <p class="govuk-body">Once you’ve fixed the error, <a
         href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
-        class="govuk-link">re-upload your file.</a>
+        class="govuk-link">re-upload your file</a>.
 </p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-boolean.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-boolean.html
@@ -1,0 +1,11 @@
+<h1 class="govuk-heading-xl">
+    Your CSV contains a value that cannot be set as 'Boolean'
+</h1>
+
+<p class="govuk-body">Your table has not been added.</p>
+<p class="govuk-body">A boolean can only be one of three possible values: true, false, or null. You have a value in a column set as 'Boolean' which is impossible.</p>
+<p class="govuk-body">You need to check all columns set as 'Boolean' data type and fix the error.</p>
+<p class="govuk-body">Once you’ve fixed the error, <a
+        href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
+        class="govuk-link">re-upload your file.</a>
+</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-date.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-date.html
@@ -10,5 +10,5 @@
 </ul>
 <p class="govuk-body">Once you’ve fixed the error, <a
     href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
-    class="govuk-link">re-upload your file.</a>
+    class="govuk-link">re-upload your file</a>.
 </p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-date.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-date.html
@@ -1,0 +1,14 @@
+<h1 class="govuk-heading-xl">
+  There's an error in a column which has been set as: 'Date'
+</h1>
+<p class="govuk-body">Your table has not been added.</p>
+<p class="govuk-body">Check all columns set as ‘Date’ data type:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>Are formatted as <a href="https://support.microsoft.com/en-gb/office/change-the-format-of-a-cell-0a45ff85-ee24-4276-94e8-aed6083e8050#:~:text=Select%20the%20cells%20with%20the,to%20change%20what%20you%20want">yyyy/mm/dd in Excel</a></li>
+  <li>only contain dates</li>
+</ul>
+<p class="govuk-body">Once you’ve fixed the error, <a
+    href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
+    class="govuk-link">re-upload your file.</a>
+</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-datetime.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-datetime.html
@@ -12,5 +12,5 @@
 </ul>
 <p class="govuk-body">Once you’ve fixed the error, <a
     href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
-    class="govuk-link">re-upload your file.</a>
+    class="govuk-link">re-upload your file</a>.
 </p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-datetime.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/setting-value-as-datetime.html
@@ -1,0 +1,16 @@
+<h1 class="govuk-heading-xl">
+  There's an error in a column which has been set as: 'Datetime'
+</h1>
+<p class="govuk-body">Your table has not been added.</p>
+<p class="govuk-body">Check all columns set as ‘Datetime’ data type:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>Are formatted as <a
+      href="https://support.microsoft.com/en-gb/office/change-the-format-of-a-cell-0a45ff85-ee24-4276-94e8-aed6083e8050#:~:text=Select%20the%20cells%20with%20the,to%20change%20what%20you%20want">yyyy/mm/dd
+      in Excel</a></li>
+  <li>only contain dates</li>
+</ul>
+<p class="govuk-body">Once you’ve fixed the error, <a
+    href="{% if next_step %}{{ next_step }}{% else %}{% url 'your_files:files' %}{% endif %}"
+    class="govuk-link">re-upload your file.</a>
+</p>

--- a/dataworkspace/dataworkspace/templates/datasets/manager/upload_failed.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manager/upload_failed.html
@@ -4,26 +4,28 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
-        We can’t process your CSV file
-      </h1>
       {% if error_message_template %}
         {% include error_message_template %}
       {% else %}
-        <p class="govuk-body">
-          Your file, {{ filename }}, cannot be processed. Please check the following before you try again.
-        </p>
-        <div class="govuk-inset-text">
-          <ul class="govuk-list govuk-list--bullet">
-            <li>Make sure the file uploaded is a CSV file</li>
-            <li>All rows in your file must have the same number of columns</li>
-            <li>Column names must be unique</li>
-          </ul>
-        </div>
+        <h1 class="govuk-heading-xl">
+          There's a problem with your CSV
+        </h1>
+        <p class="govuk-body">Your table has not been added.</p>
+        <p class="govuk-body">There's an error in your CSV. Data Workspace cannot identify what caused the error or what column it's in.</p>
+        <p class="govuk-body">You need to check:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>you have followed the steps on the <a href="{{ next_step }}">upload page</a></li>
+          <li>you have chosen data types that can describe your data</li>
+        </ul>
       {% endif %}
-      <p class="govuk-body">
-        <a href="{{ next_step }}" class="govuk-link">Return to dataset upload page</a>
-      </p>
+
+      <h2 class="govuk-heading-m">If you continue to get an error</h2>
+
+      <p class="govuk-body">Data Workspace can only identify one error at a time. This means that you could get the same or a different error more
+      than once. If this happens you'll need to fix each error in turn.</p>
+
+      <p class="govuk-body">If you're unable to solve your error, <a href="/contact-us" class="govuk-link">contact us</a></p>
+
     </div>
   </div>
 {% endblock content %}

--- a/dataworkspace/dataworkspace/templates/datasets/manager/upload_failed.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manager/upload_failed.html
@@ -24,7 +24,7 @@
       <p class="govuk-body">Data Workspace can only identify one error at a time. This means that you could get the same or a different error more
       than once. If this happens you'll need to fix each error in turn.</p>
 
-      <p class="govuk-body">If you're unable to solve your error, <a href="/contact-us" class="govuk-link">contact us</a></p>
+      <p class="govuk-body">If you're unable to solve your error, <a href="/contact-us" class="govuk-link">contact us</a>.</p>
 
     </div>
   </div>

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-failed.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-failed.html
@@ -3,26 +3,28 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
-        We can’t process your CSV file
-      </h1>
       {% if error_message_template %}
         {% include error_message_template %}
       {% else %}
-        <p class="govuk-body">
-          Your file, {{ filename }}, cannot be processed. Please check the following before you try again.
-        </p>
-        <div class="govuk-inset-text">
+        <h1 class="govuk-heading-xl">
+          There’s a problem with your CSV
+        </h1>
+          <p class="govuk-body">Your table has not been added.</p>
+          <p class="govuk-body">There's an error in your CSV. Data Workspace cannot identify what caused the error or what column
+            it's in.</p>
+          <p class="govuk-body">You need to check:</p>
           <ul class="govuk-list govuk-list--bullet">
-            <li>Make sure the file uploaded is a CSV file</li>
-            <li>All rows in your file must have the same number of columns</li>
-            <li>Column names must be unique</li>
+            <li>you have followed the steps on the <a href="{% url 'your_files:files' %}">upload page</a></li>
+            <li>you have chosen data types that can describe your data</li>
           </ul>
-        </div>
       {% endif %}
-      <p class="govuk-body">
-        <a href="{% url 'your_files:files' %}" class="govuk-link">Return to your files</a>
-      </p>
+      <h2 class="govuk-heading-m">If you continue to get an error</h2>
+      
+      <p class="govuk-body">Data Workspace can only identify one error at a time. This means that you could get the same or a
+        different error more
+        than once. If this happens you'll need to fix each error in turn.</p>
+      
+      <p class="govuk-body">If you're unable to solve your error, <a href="/contact-us" class="govuk-link">contact us</a></p>
     </div>
   </div>
 {% endblock content %}

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-failed.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-failed.html
@@ -24,7 +24,7 @@
         different error more
         than once. If this happens you'll need to fix each error in turn.</p>
       
-      <p class="govuk-body">If you're unable to solve your error, <a href="/contact-us" class="govuk-link">contact us</a></p>
+      <p class="govuk-body">If you're unable to solve your error, <a href="/contact-us" class="govuk-link">contact us</a>.</p>
     </div>
   </div>
 {% endblock content %}

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4764,11 +4764,49 @@ class TestDatasetManagerViews:
     @pytest.mark.parametrize(
         "log_message,expected_text",
         [
-            ("Generic Error", b"Please check the following before you try again"),
-            ("UnicodeDecodeError", b"character encoding error"),
-            ("Invalid input syntax for type Numeric", b"error parsing a numeric field"),
-            ("NumericValueOutOfRange", b"out of range error"),
-            ("DatetimeFieldOverflow", b"error parsing a date field"),
+            (
+                "is of type bigint but expression is of type boolean",
+                b"There's an error in a column which has been set as: 'Integer'",
+            ),
+            (
+                "is of type numeric but expression is of type boolean",
+                b"There's an error in a column which has been set as: 'Numeric'",
+            ),
+            (
+                "is of type date but expression is of type boolean",
+                b"There's an error in a column which has been set as: 'Date'",
+            ),
+            (
+                "is of type timestamp with time zone but expression is of type boolean",
+                b"There's an error in a column which has been set as: 'Datetime'",
+            ),
+            ("Not a boolean value", b"Your CSV contains a value that cannot be set as 'Boolean'"),
+            (
+                "invalid input syntax for type bigint",
+                b"Your CSV contains a 'String' value that cannot be set as 'Integer'",
+            ),
+            (
+                "invalid input syntax for type numeric",
+                b"Your CSV contains a 'String' value that cannot be set as 'Numeric'",
+            ),
+            ("is of type date", b"There's an error in a column which has been set as: 'Date'"),
+            (
+                "invalid input syntax for type date",
+                b"There's an error in a column which has been set as: 'Date'",
+            ),
+            (
+                "is of type timestamp",
+                b"There's an error in a column which has been set as: 'Datetime'",
+            ),
+            (
+                "invalid input syntax for type timestamp",
+                b"There's an error in a column which has been set as: 'Datetime'",
+            ),
+            (
+                "date/time field value out of range",
+                b"Your CSV contains a date that cannot be correct",
+            ),
+            ("some other error", b"There's a problem with your CSV"),
         ],
     )
     @mock.patch("dataworkspace.apps.core.utils.get_dataflow_task_log")

--- a/dataworkspace/dataworkspace/tests/your_files/test_views.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_views.py
@@ -33,7 +33,7 @@ class TestCreateTableViews:
             data={"path": "not-a-csv.txt"},
             follow=True,
         )
-        assert "We can’t process your CSV file" in response.content.decode("utf-8")
+        assert "There’s a problem with your CSV" in response.content.decode("utf-8")
 
     @mock.patch("dataworkspace.apps.your_files.forms.get_user_s3_prefixes")
     def test_unauthorised_file(self, mock_get_s3_prefix, client):
@@ -43,7 +43,7 @@ class TestCreateTableViews:
             data={"path": "user/federated/def/a-csv.csv"},
             follow=True,
         )
-        assert "We can’t process your CSV file" in response.content.decode("utf-8")
+        assert "There’s a problem with your CSV" in response.content.decode("utf-8")
 
     @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_user_s3_prefixes")
@@ -60,7 +60,7 @@ class TestCreateTableViews:
             data={"path": "user/federated/abc/a-csv.csv"},
             follow=True,
         )
-        assert "We can’t process your CSV file" in response.content.decode("utf-8")
+        assert "There’s a problem with your CSV" in response.content.decode("utf-8")
 
     @mock.patch("dataworkspace.apps.your_files.views.copy_file_to_uploads_bucket")
     @mock.patch("dataworkspace.apps.your_files.views.get_s3_csv_file_info")
@@ -111,7 +111,7 @@ class TestCreateTableViews:
                 follow=True,
             )
 
-        assert "We can’t process your CSV file" in response.content.decode("utf-8")
+        assert "There’s a problem with your CSV" in response.content.decode("utf-8")
 
     @freeze_time("2021-01-01 01:01:01")
     @mock.patch("dataworkspace.apps.your_files.views.trigger_dataflow_dag")


### PR DESCRIPTION
### Description of change
This change updates/creates useful error pages for when the user fails to create a table in the following journeys:

1. Data catalogue page - update/restore
2. Your files - create table 

To show useful error messages on these pages we are reading the error messages in Air Flow, running a regex on the log and then based on certain conditions we surface content related to that error.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?