### PR TITLE
Remove Stata permission from self certify flow

### DIFF
--- a/dataworkspace/dataworkspace/apps/request_access/views.py
+++ b/dataworkspace/dataworkspace/apps/request_access/views.py
@@ -277,7 +277,6 @@ class SelfCertifyView(FormView):
         permission_codenames = [
             "start_all_applications",
             "develop_visualisations",
-            "access_appstream",
             "access_quicksight",
         ]
         content_type = ContentType.objects.get_for_model(ApplicationInstance)

--- a/dataworkspace/dataworkspace/tests/request_access/test_views.py
+++ b/dataworkspace/dataworkspace/tests/request_access/test_views.py
@@ -572,7 +572,7 @@ class TestSelfCertify(TestCase):
         self.user.refresh_from_db()
         user_permissions = self.user.user_permissions.all()
 
-        assert user_permissions.count() == 4
+        assert user_permissions.count() == 3
         assert response.status_code == 302
 
     def test_form_valid_redirects_to_tools_page(self):


### PR DESCRIPTION
### Description of change
Removed appstream permission (For Stata) from the list of permissions that are granted during self certify as Stata has it's own request access flow

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?