### PR TITLE
Add space between commas in publisher list

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -420,7 +420,7 @@ class DatasetDetailView(DetailView):
         return source_text
 
     def _get_publisher_text(self, model):
-        publisher_text = ",".join(
+        publisher_text = ", ".join(
             sorted({t.name for t in self.object.tags.filter(type=TagType.PUBLISHER)})
         )
         return publisher_text


### PR DESCRIPTION
### Description of change
Add spacing between commas in list of Publishers on catalogue pages

![Screenshot 2024-06-27 at 13 17 21](https://github.com/uktrade/data-workspace-frontend/assets/54268863/faeb353a-27dc-4742-bcf9-8187ccc4b314)
To test, add a couple publisher tags to a dataset in Django Admin and view on the catalogue page.
### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?