### PR TITLE
Update link in code snippets to redirect to tools page

### DIFF
--- a/dataworkspace/dataworkspace/templates/partials/code_snippets.html
+++ b/dataworkspace/dataworkspace/templates/partials/code_snippets.html
@@ -30,7 +30,7 @@
 
       <div class="govuk-button-group">
         <a id="launch-data-explorer" class="govuk-button govuk-!-margin-top-5" href="{% url 'explorer:index' %}?sql={{ code_snippets.sql|quote_plus }}" target="_blank">Open <span class="govuk-visually-hidden">first 50 rows of "{{ source_table.schema }}"."{{ source_table.table }}" </span>in Data Explorer</a>            
-          <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
+          <a href="/tools" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>
 
@@ -44,7 +44,7 @@
 
       <div class="govuk-button-group govuk-!-margin-top-5" id="launch-jupyter-lab">
           <a class="govuk-button" href="{{ tools_links.jupyterlab_link }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>JupyterLab</a>
-          <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
+          <a href="/tools" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>
 
@@ -58,7 +58,7 @@
 
       <div class="govuk-button-group govuk-!-margin-top-5" id="launch-r-studio">
         <a class="govuk-button" href="{{ tools_links.rstudio_link }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>R Studio</a>
-        <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
+        <a href="/tools" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>
 


### PR DESCRIPTION
### Description of change
When a user is looking at a table and they select ‘Use this data for analysis at the top of the page’, a link which says ‘View all tools’ should now send the user to the correct page (/tools)

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?