### PR TITLE
Chore/dependencies 2024 07 11

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -141,7 +141,7 @@ decorator==4.4.2
     # via ipython
 dj-database-url==0.5.0
     # via -r requirements.txt
-django==4.2.11
+django==4.2.14
     # via
     #   -r requirements.txt
     #   django-admin-sortable2

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ cryptography==42.0.5
     # via -r requirements.in
 dj-database-url==0.5.0
     # via -r requirements.in
-django==4.2.11
+django==4.2.14
     # via
     #   -r requirements.in
     #   django-admin-sortable2


### PR DESCRIPTION
- Bump Django from 4.2.11 to 4.2.14
- Bump zipp from 3.8.0 to 3.19.1