### PR TITLE
Feat/DT-2051: Add the first page for the new "add table" journey

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/add_table/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/urls.py
@@ -1,0 +1,15 @@
+from django.urls import path
+
+from dataworkspace.apps.accounts.utils import login_required
+from dataworkspace.apps.datasets.add_table.views import (
+    AddTableView,
+)
+
+
+urlpatterns = [
+    path(
+        "",
+        login_required(AddTableView.as_view()),
+        name="add-table",
+    ),
+]

--- a/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
@@ -1,0 +1,11 @@
+from django.views.generic import TemplateView
+from django.urls import reverse
+
+
+class AddTableView(TemplateView):
+    template_name = "datasets/add_table/about_this_service.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["backlink"] = reverse("datasets:dataset_detail", args={kwargs["pk"]})
+        return context

--- a/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
@@ -1,6 +1,5 @@
 from django.views.generic import DetailView
 from django.urls import reverse
-from dataworkspace.apps.datasets import models
 from dataworkspace.apps.datasets.utils import find_dataset
 
 

--- a/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
@@ -1,11 +1,18 @@
-from django.views.generic import TemplateView
+from django.views.generic import DetailView
 from django.urls import reverse
+from dataworkspace.apps.datasets import models
+from dataworkspace.apps.datasets.utils import find_dataset
 
 
-class AddTableView(TemplateView):
+class AddTableView(DetailView):
     template_name = "datasets/add_table/about_this_service.html"
 
+    def get_object(self, queryset=None):
+        return find_dataset(self.kwargs["pk"], self.request.user)
+
     def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["backlink"] = reverse("datasets:dataset_detail", args={kwargs["pk"]})
-        return context
+        ctx = super().get_context_data(**kwargs)
+        ctx["model"] = self.object
+        ctx["backlink"] = reverse("datasets:dataset_detail", args={self.kwargs["pk"]})
+
+        return ctx

--- a/dataworkspace/dataworkspace/apps/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/urls.py
@@ -305,4 +305,11 @@ urlpatterns = [
         {"model_class": models.ReferenceDataset},
         name="reference_dataset_save_grid_view",
     ),
+    path(
+        "<uuid:pk>/add-table/",
+        include(
+            ("dataworkspace.apps.datasets.add_table.urls", "dataset_add_table"),
+            namespace="add_table",
+        ),
+    ),
 ]

--- a/dataworkspace/dataworkspace/templates/datasets/add_table/about_this_service.html
+++ b/dataworkspace/dataworkspace/templates/datasets/add_table/about_this_service.html
@@ -24,7 +24,7 @@
                 <li>large datasets with lots of columns</li>
                 </ul>
             <p class="govuk-body">We may be able to help you automate this type of upload. To get advice on if automation is right for your datasets,
-            <a class="govuk-link" href="/support-and-feedback/">contact us (opens in new tab).</a>
+            <a class="govuk-link" href="/support-and-feedback/">contact us (opens in new tab)</a>.
             </p> 
           
         <div class="govuk-button-group">

--- a/dataworkspace/dataworkspace/templates/datasets/add_table/about_this_service.html
+++ b/dataworkspace/dataworkspace/templates/datasets/add_table/about_this_service.html
@@ -1,0 +1,43 @@
+ {% extends '_main.html' %}
+
+
+{% block page_title %}Add Table - {{ dataset.name }} - {{ block.super }}{% endblock %}
+
+{% if backlink %}
+  {% block go_back %}
+    <a href="{{ backlink }}" class="govuk-back-link">Back</a>
+  {% endblock %}
+{% endif %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">About this service</h1>
+
+        <p class="govuk-body">Use this service to turn a CSV file into a data table. The new table will be added to this catalogue item.</p>
+
+        <h2 class="govuk-heading-m">When you should not use this service</h2>
+
+            <p class="govuk-body">Do not use this service if you're regularly uploading:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                <li>a lot of datasets</li>
+                <li>large datasets with lots of columns</li>
+                </ul>
+            <p class="govuk-body">We may be able to help you automate this type of upload. To get advice on if automation is right for your datasets,
+            <a class="govuk-link" href="/support-and-feedback/">contact us.</a>
+            </p> 
+          
+        <div class="govuk-button-group">
+        <a href="#" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+            Start now
+            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+            </svg>
+        </a>
+        <a href="{{ backlink }}" class="govuk-link govuk-link--no-visited-state"> 
+            Cancel
+         </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/add_table/about_this_service.html
+++ b/dataworkspace/dataworkspace/templates/datasets/add_table/about_this_service.html
@@ -1,7 +1,7 @@
  {% extends '_main.html' %}
 
 
-{% block page_title %}Add Table - {{ dataset.name }} - {{ block.super }}{% endblock %}
+{% block page_title %}Add Table - {{ model.name }} - {{ block.super }}{% endblock %}
 
 {% if backlink %}
   {% block go_back %}
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">About this service</h1>
 
-        <p class="govuk-body">Use this service to turn a CSV file into a data table. The new table will be added to this catalogue item.</p>
+        <p class="govuk-body">Use this service to turn a CSV file into a data table. The new table will be added to {{model.name}}.</p>
 
         <h2 class="govuk-heading-m">When you should not use this service</h2>
 
@@ -24,7 +24,7 @@
                 <li>large datasets with lots of columns</li>
                 </ul>
             <p class="govuk-body">We may be able to help you automate this type of upload. To get advice on if automation is right for your datasets,
-            <a class="govuk-link" href="/support-and-feedback/">contact us.</a>
+            <a class="govuk-link" href="/support-and-feedback/">contact us (opens in new tab).</a>
             </p> 
           
         <div class="govuk-button-group">

--- a/dataworkspace/dataworkspace/templates/datasets/add_table/about_this_service.html
+++ b/dataworkspace/dataworkspace/templates/datasets/add_table/about_this_service.html
@@ -24,7 +24,7 @@
                 <li>large datasets with lots of columns</li>
                 </ul>
             <p class="govuk-body">We may be able to help you automate this type of upload. To get advice on if automation is right for your datasets,
-            <a class="govuk-link" href="/support-and-feedback/">contact us (opens in new tab)</a>.
+            <a class="govuk-link" href="/support-and-feedback/" target="_blank">contact us (opens in new tab)</a>.
             </p> 
           
         <div class="govuk-button-group">

--- a/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
@@ -8,21 +8,28 @@ from dataworkspace.tests.common import get_http_sso_data
 
 
 @pytest.mark.django_db
-def test_about_service():
+def test_about_service_page():
     user = factories.UserFactory.create(is_superuser=False)
     client = Client(**get_http_sso_data(user))
     dataset = factories.MasterDataSetFactory.create(
         published=True, user_access_type=UserAccessType.REQUIRES_AUTHORIZATION
     )
-    print("dataset", dataset.id)
+
     response = client.get(
         reverse("datasets:add_table:add-table", kwargs={"pk": dataset.id}),
     )
     soup = BeautifulSoup(response.content.decode(response.charset))
     header_one = soup.find("h1")
     header_two = soup.find("h2")
+    paragraph = soup.find("p")
     header_one_text = header_one.contents
     header_two_text = header_two.contents
+    paragraph_text = paragraph.contents
+    print("paragraph", paragraph_text)
     assert response.status_code == 200
     assert "About this service" in header_one_text
     assert "When you should not use this service" in header_two_text
+    assert (
+        f"Use this service to turn a CSV file into a data table. The new table will be added to {dataset.name}."
+        in paragraph_text
+    )

--- a/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
@@ -1,0 +1,28 @@
+import pytest
+from bs4 import BeautifulSoup
+from django.urls import reverse
+from django.test import Client
+from dataworkspace.tests import factories
+from dataworkspace.apps.datasets.constants import UserAccessType
+from dataworkspace.tests.common import get_http_sso_data
+
+
+@pytest.mark.django_db
+def test_about_service():
+    user = factories.UserFactory.create(is_superuser=False)
+    client = Client(**get_http_sso_data(user))
+    dataset = factories.MasterDataSetFactory.create(
+        published=True, user_access_type=UserAccessType.REQUIRES_AUTHORIZATION
+    )
+    print("dataset", dataset.id)
+    response = client.get(
+        reverse("datasets:add_table:add-table", kwargs={"pk": dataset.id}),
+    )
+    soup = BeautifulSoup(response.content.decode(response.charset))
+    header_one = soup.find("h1")
+    header_two = soup.find("h2")
+    header_one_text = header_one.contents
+    header_two_text = header_two.contents
+    assert response.status_code == 200
+    assert "About this service" in header_one_text
+    assert "When you should not use this service" in header_two_text

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4962,13 +4962,3 @@ def test_master_dataset_detail_page_shows_pipeline_failures(client, metadata_db)
         len([x for x in response.context["master_datasets_info"] if x.pipeline_last_run_succeeded])
         == 1
     )
-
-
-def test_AddTableView(client):
-    ds = factories.DataSetFactory.create()
-    url_datasets = reverse("datasets:dataset_detail", args=(ds.id,))
-    url_add_data_html = f"{url_datasets}/add_data"
-
-    response = client.get(url_add_data_html)
-    assert response.status_code == 200
-    assert "About this service" in str(response.content)

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4962,3 +4962,13 @@ def test_master_dataset_detail_page_shows_pipeline_failures(client, metadata_db)
         len([x for x in response.context["master_datasets_info"] if x.pipeline_last_run_succeeded])
         == 1
     )
+
+
+def test_AddTableView(client):
+    ds = factories.DataSetFactory.create()
+    url_datasets = reverse("datasets:dataset_detail", args=(ds.id,))
+    url_add_data_html = f"{url_datasets}/add_data"
+
+    response = client.get(url_add_data_html)
+    assert response.status_code == 200
+    assert "About this service" in str(response.content)


### PR DESCRIPTION
### Description of change

Ticket [DT-2051](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-2051)

This change is the start of the new "add table" journey. 

How to test

1. Visit any data catalogue page
2. Add `/add-table` to the end of the url

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?

[DT-2051]: https://uktrade.atlassian.net/browse/DT-2051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ