### PR TITLE
fix: avoid undoing recent VisualisationLink changes

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -362,7 +362,7 @@ def process_quicksight_dashboard_visualisations():
                     dashboard_id,
                 )
                 visualisation_link.data_source_last_updated = max(last_updated_dates)
-                visualisation_link.save()
+                visualisation_link.save(update_fields=["data_source_last_updated"])
 
             if tables:
                 set_dataset_related_visualisation_catalogue_items(visualisation_link, tables)


### PR DESCRIPTION
### Description of change

It's been reported that changing details of VisualisationLinks appear to work, but then are undone within a few minutes. Although we're not 100% sure, it could be due to background tasks that query for VisualisationLink instances, do slow tasks, and then save all the fields of the model instance, and thus undoing any interim changes to the model instance.

We fix this by using the `update_fields` option of the save method to only save the specific fields that should be being saved, and thus not undoing any recent changes persisted in the database.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?