### PR TITLE
fix: avoid multiple process_quicksight_dashboard_visualisations

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -217,6 +217,18 @@ tryCatch({{
 @celery_app.task()
 @close_all_connections_if_not_in_atomic_block
 def process_quicksight_dashboard_visualisations():
+    try:
+        with cache.lock(
+            "process_quicksight_dashboard_visualisations_lock", blocking_timeout=0, timeout=3600
+        ):
+            do_process_quicksight_dashboard_visualisations()
+    except LockError as e:
+        logger.warning(
+            "Failed to acquire lock for process_quicksight_dashboard_visualisations: %s", e
+        )
+
+
+def do_process_quicksight_dashboard_visualisations():
     """
     Loop over all VisualisationLink objects and do the following:
 


### PR DESCRIPTION
### Description of change

It looks like we're running multiple process_quicksight_dashboard_visualisations at once - it's set to start every 5 minutes but it might be taking longer than 5 minutes these days.

By wrapping the code that does the work in a lock this should avoid the problem. This pattern is already in use for other scheduled Celery tasks.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?