### PR TITLE
feat: make Arango's nice domain work from tools

### DIFF
--- a/dns-rewrite-proxy/nameserver.py
+++ b/dns-rewrite-proxy/nameserver.py
@@ -46,9 +46,9 @@ async def async_main():
 
     start = DnsProxy(
         rules=(
-            # The docker registry host in the public zone will already correctly
+            # The arango host in the public zone will already correctly
             # resolve to the private IP, so we pass that through
-            (r"^(registry\." + public_zone + ")$", r"\1"),
+            (r"^(arango\." + public_zone + ")$", r"\1"),
             # ... other public zone hosts should resolve to the IP of the
             # private zone, e.g. gitlab
             (r"^(.+)\." + public_zone + "$", r"\1." + private_zone),


### PR DESCRIPTION
### Description of change

The dns-rewrite-proxy rewrites and filters certain DNS requests (it was created before AWS could do this with their DNS firewall). One of the things it does it rewrites <host>.<public-domain> to <host>.<private-domain> in tools so that the same domain can be used from outside of tools as well as in (for example, GitLab).

However, the arango host under (for example) data.trade.gov.uk resolves to the internal load balancer, and so we don't need the rewriting, because there is no arango.<private-domain>.

Also the Docker registry has not existed for several years - so this repurposes its entry in the rewrite list for Arango.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?