### PR TITLE
feature/read-sso-users-from-S3

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -7,6 +7,8 @@ import re
 import urllib.parse
 from collections import defaultdict
 from typing import Dict, List
+from dateutil import parser
+from dateutil.tz import tzlocal
 
 import boto3
 import botocore
@@ -25,6 +27,8 @@ from psycopg2 import connect, sql
 import requests
 from mohawk import Sender
 from pytz import utc
+from smart_open import open as smart_open
+
 import redis
 
 from dataworkspace.apps.accounts.models import Profile
@@ -67,7 +71,8 @@ from dataworkspace.apps.datasets.models import (
 )
 from dataworkspace.cel import celery_app
 from dataworkspace.datasets_db import extract_queried_tables_from_sql_query
-from dataworkspace.apps.core.boto3_client import get_sts_client
+from dataworkspace.apps.core.boto3_client import get_s3_resource, get_sts_client
+
 
 logger = logging.getLogger("app")
 
@@ -1282,6 +1287,120 @@ def _do_sync_activity_stream_sso_users(page_size=1000):
         "sync_activity_stream_sso_users: Finished with new last published date of %s",
         last_published,
     )
+
+
+@celery_app.task(autoretry_for=(redis.exceptions.LockError,))
+@close_all_connections_if_not_in_atomic_block
+def sync_s3_sso_users():
+    try:
+        with cache.lock("sso_sync_last_published_lock", blocking_timeout=0, timeout=1800):
+            _do_sync_s3_sso_users()
+    except redis.exceptions.LockError:
+        logger.info("sync_s3_sso_users: Unable to acquire lock. Not running")
+
+
+def _do_get_staff_sso_s3_object_summaries(s3_bucket):
+    logger.info("sync_s3_sso_users: Reading files from bucket %s", s3_bucket)
+    files = s3_bucket.objects.filter(Prefix="data-flow-exports")
+    # Get the list of files, oldest first. Process in that order, so any changes in newer files take precedence
+    sorted_files = sorted(files, key=lambda x: x.last_modified, reverse=False)
+    for file in sorted_files:
+        file.source_key = f"s3://{file.bucket_name}/{file.key}"
+        logger.info("sync_s3_sso_users: Found S3 file with key %s", file.source_key)
+    return sorted_files
+
+
+def _process_staff_sso_file(client, source_key, last_processed_datetime):
+    new_last_processed_datetime = last_processed_datetime
+    with smart_open(
+        source_key,
+        "r",
+        transport_params={
+            "client": client,
+        },
+        encoding="utf-8",
+    ) as file_input_stream:  # type: ignore
+        logger.info("sync_s3_sso_users: Processing file %s", source_key)
+        for line in file_input_stream:
+
+            user = json.loads(line)
+            published = user.get("published")
+
+            published_date = parser.parse(published)
+
+            if published_date < last_processed_datetime:
+                # This items published date is before the last processed date, can be ignored
+                continue
+
+            user_obj = user["object"]
+            user_id = user_obj.get("dit:StaffSSO:User:userId")
+            emails = user_obj.get("dit:emailAddress", [])
+            primary_email = user_obj.get("dit:StaffSSO:User:contactEmailAddress") or emails[0]
+            first_name = user_obj.get("dit:firstName")
+            last_name = user_obj.get("dit:lastName")
+            status = user_obj.get("dit:StaffSSO:User:status")
+
+            if settings.S3_SSO_IMPORT_ENABLED:
+                logger.info(
+                    "sync_s3_sso_users: User id %s published date %s is after previous date %s, creating the user from sso",
+                    user_id,
+                    published_date,
+                    last_processed_datetime,
+                )
+                try:
+                    create_user_from_sso(
+                        user_id,
+                        primary_email,
+                        first_name,
+                        last_name,
+                        status,
+                        check_tools_access_if_user_exists=True,
+                    )
+
+                    if published_date > new_last_processed_datetime:
+                        new_last_processed_datetime = published_date
+                except IntegrityError:
+                    logger.exception("sync_s3_sso_users: Failed to create user record")
+            else:
+                logger.info("S3_SSO_IMPORT_ENABLED is disabled, user will not be added")
+
+    return new_last_processed_datetime
+
+
+def _do_sync_s3_sso_users():
+    last_published = cache.get(
+        "s3_sso_sync_last_published",
+        datetime.datetime.fromtimestamp(0, tz=tzlocal()),
+    )
+    logger.info("sync_s3_sso_users: Starting with last published date of %s", last_published)
+    ten_seconds_before_last_published = last_published - datetime.timedelta(seconds=10)
+
+    new_last_processed = last_published
+
+    # There should only be one file as we delete the files once processed, however the pipeline
+    # frequency might be increased and there are multiple files we need to process. How do we
+    # handle multiple files, with the same data in both? Which file takes priority. Start by processing oldest to newest
+
+    s3_resource = get_s3_resource()
+    bucket = s3_resource.Bucket(settings.AWS_UPLOADS_BUCKET)
+    files = _do_get_staff_sso_s3_object_summaries(bucket)
+
+    for file in files:
+        new_last_processed = _process_staff_sso_file(
+            s3_resource.meta.client, file.source_key, ten_seconds_before_last_published
+        )
+    logger.info("sync_s3_sso_users: New last_published date for cache %s", new_last_processed)
+
+    # At the end of the loop, delete all loaded files
+    if len(files) > 0:
+        delete_keys = [{"Key": file.key} for file in files]
+        logger.info("sync_s3_sso_users: Deleting keys %s", delete_keys)
+        bucket.delete_objects(Delete={"Objects": delete_keys})
+    else:
+        logger.info("sync_s3_sso_users: No files to delete")
+
+    # At the end of the loop set the cache
+    cache.set("s3_sso_sync_last_published", new_last_processed)
 
 
 def fetch_visualisation_log_events(log_group, log_stream):

--- a/dataworkspace/dataworkspace/apps/core/boto3_client.py
+++ b/dataworkspace/dataworkspace/apps/core/boto3_client.py
@@ -14,6 +14,14 @@ def get_s3_client():
     return boto3.client("s3")
 
 
+def get_s3_resource():
+    if settings.S3_LOCAL_ENDPOINT_URL:
+        logger.debug("using local S3 endpoint %s", settings.S3_LOCAL_ENDPOINT_URL)
+        return boto3.resource("s3", endpoint_url=settings.S3_LOCAL_ENDPOINT_URL)
+
+    return boto3.resource("s3")
+
+
 def get_sts_client():
     if settings.STS_LOCAL_ENDPOINT_URL:
         logger.debug("get_sts_client using %s", settings.STS_LOCAL_ENDPOINT_URL)

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -376,6 +376,11 @@ if not strtobool(env.get("DISABLE_CELERY_BEAT_SCHEDULE", "0")):
             "schedule": 60 * 2,
             "args": (),
         },
+        "sync-sso-users-from-sso": {
+            "task": "dataworkspace.apps.applications.utils.sync_s3_sso_users",
+            "schedule": crontab(minute="*/15"),  # Run every 15 minutes
+            "args": (),
+        },
         "sync-tool-query-logs": {
             "task": "dataworkspace.apps.applications.utils.sync_tool_query_logs",
             "schedule": 60 * 2,
@@ -479,6 +484,7 @@ S3_POLICY_DOCUMENT_TEMPLATE = base64.b64decode(env["S3_POLICY_DOCUMENT_TEMPLATE_
 S3_PERMISSIONS_BOUNDARY_ARN = env["S3_PERMISSIONS_BOUNDARY_ARN"]
 S3_ROLE_PREFIX = env["S3_ROLE_PREFIX"]
 S3_NOTEBOOKS_BUCKET_ARN = env["S3_NOTEBOOKS_BUCKET_ARN"]
+S3_SSO_IMPORT_ENABLED = env.get("S3_SSO_IMPORT_ENABLED", False)
 EFS_ID = env["EFS_ID"]
 
 YOUR_FILES_ENABLED = env.get("YOUR_FILES_ENABLED", "False") == "True"

--- a/dataworkspace/dataworkspace/tests/applications/conftest.py
+++ b/dataworkspace/dataworkspace/tests/applications/conftest.py
@@ -1,0 +1,26 @@
+import datetime
+from uuid import uuid4
+import pytest
+
+from faker import Faker
+
+
+@pytest.fixture
+def sso_user_factory():
+
+    faker = Faker()
+
+    def _factory(published_date=None):
+        published_date = datetime.datetime.today() if published_date is None else published_date
+        return {
+            "published": published_date.strftime("%Y%m%dT%H%M%S.%dZ"),
+            "object": {
+                "dit:StaffSSO:User:userId": str(uuid4()),
+                "dit:emailAddress": [faker.email()],
+                "dit:firstName": faker.first_name(),
+                "dit:lastName": faker.last_name(),
+                "dit:StaffSSO:User:status": "active",
+            },
+        }
+
+    return _factory

--- a/localstack/init/buckets.sh
+++ b/localstack/init/buckets.sh
@@ -2,7 +2,9 @@
 set -x
 awslocal s3 mb s3://notebooks.dataworkspace.local
 awslocal s3 mb s3://uploads.dataworkspace.local
+
 # Multipart file uploads from Your Files in the browser require ETag to be
 # exposed but by default it's not, so we add a CORS config to expose it
 awslocal s3api put-bucket-cors --bucket notebooks.dataworkspace.local --cors-configuration file:///docker-entrypoint-initaws.d/s3-cors.json
+
 set +x


### PR DESCRIPTION
### Description of change
Add a new celery task that will call the S3 bucket every 15 minutes to get the list of files produced by data flow. Each file will then be processed to get a list of all users in that file, and any new ones will be added to data workspace

For now, the task will run and query the files, but the users won't be imported. This is to allow fixing any permission issues, whilst allowing users to still be created by the activity stream celery task

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?