### PR TITLE
Feat/dt 2190 Remove tools access for users with expired certificates

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -1,4 +1,3 @@
-import calendar
 import csv
 import datetime
 import json
@@ -64,6 +63,7 @@ from dataworkspace.apps.core.utils import (
     transaction_and_lock,
     new_private_database_credentials,
     postgres_user,
+    has_tools_cert_expired,
 )
 from dataworkspace.apps.applications.gitlab import gitlab_has_developer_access
 from dataworkspace.apps.datasets.constants import UserAccessType
@@ -2110,13 +2110,6 @@ def remove_tools_access_for_users_with_expired_cert():
         logger.info("remove_tools_access: Lock not owned - running on another instance?")
     except redis.exceptions.LockError:
         logger.info("remove_tools_access: Unable to grab lock - running on another instance?")
-
-
-def has_tools_cert_expired(cert_date):
-    given_datetime = datetime.datetime.combine(cert_date, datetime.datetime.min.time())
-    total_days = 366 if calendar.isleap(datetime.date.today().year) else 365
-    one_year_ago = datetime.datetime.now() - datetime.timedelta(days=total_days)
-    return bool(one_year_ago >= given_datetime or given_datetime > datetime.datetime.now())
 
 
 def _remove_tools_access_for_users_with_expired_cert():

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -2112,6 +2112,13 @@ def remove_tools_access_for_users_with_expired_cert():
         logger.info("remove_tools_access: Unable to grab lock - running on another instance?")
 
 
+def has_tools_cert_expired(cert_date):
+    given_datetime = datetime.datetime.combine(cert_date, datetime.datetime.min.time())
+    total_days = 366 if calendar.isleap(datetime.date.today().year) else 365
+    one_year_ago = datetime.datetime.now() - datetime.timedelta(days=total_days)
+    return bool(one_year_ago >= given_datetime or given_datetime > datetime.datetime.now())
+
+
 def _remove_tools_access_for_users_with_expired_cert():
     logger.info("_remove_tools_access: Start")
     user_model = get_user_model()
@@ -2122,12 +2129,6 @@ def _remove_tools_access_for_users_with_expired_cert():
         "access_appstream",
     ]
     permission_ids = Permission.objects.filter(codename__in=permissions_codenames).all()
-
-    def has_tools_cert_expired(cert_date):
-        given_datetime = datetime.datetime.combine(cert_date, datetime.datetime.min.time())
-        total_days = 366 if calendar.isleap(datetime.date.today().year) else 365
-        one_year_ago = datetime.datetime.now() - datetime.timedelta(days=total_days)
-        return bool(one_year_ago >= given_datetime or given_datetime > datetime.datetime.now())
 
     def remove_tools_access(user):
         for permission_id in permission_ids:

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -1,3 +1,4 @@
+import calendar
 import csv
 import datetime
 import json
@@ -17,6 +18,7 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
@@ -2094,3 +2096,49 @@ def get_tool_url_for_user(user: get_user_model(), application_template: Applicat
     user_prefix = stable_identification_suffix(str(user.profile.sso_id), short=True)
     hostname = application_template.host_basename
     return f"https://{hostname}-{user_prefix}.{settings.APPLICATION_ROOT_DOMAIN}/"
+
+
+@celery_app.task()
+@close_all_connections_if_not_in_atomic_block
+def remove_tools_access_for_users_with_expired_cert():
+    try:
+        with cache.lock(
+            "_remove_tools_access_for_users_with_expired_cert", blocking_timeout=0, timeout=1800
+        ):
+            _remove_tools_access_for_users_with_expired_cert()
+    except redis.exceptions.LockNotOwnedError:
+        logger.info("remove_tools_access: Lock not owned - running on another instance?")
+    except redis.exceptions.LockError:
+        logger.info("remove_tools_access: Unable to grab lock - running on another instance?")
+
+
+def _remove_tools_access_for_users_with_expired_cert():
+    logger.info("_remove_tools_access: Start")
+    user_model = get_user_model()
+    permissions_codenames = [
+        "start_all_applications",
+        "develop_visualisations",
+        "access_quicksight",
+        "access_appstream",
+    ]
+    permission_ids = Permission.objects.filter(codename__in=permissions_codenames).all()
+
+    def has_tools_cert_expired(cert_date):
+        given_datetime = datetime.datetime.combine(cert_date, datetime.datetime.min.time())
+        total_days = 366 if calendar.isleap(datetime.date.today().year) else 365
+        one_year_ago = datetime.datetime.now() - datetime.timedelta(days=total_days)
+        return bool(one_year_ago >= given_datetime or given_datetime > datetime.datetime.now())
+
+    def remove_tools_access(user):
+        for permission_id in permission_ids:
+            user.user_permissions.remove(permission_id.id)
+
+    for user in user_model.objects.all():
+        user_has_access = user.user_permissions.filter(codename__in=permissions_codenames).exists()
+        user_profile = Profile.objects.filter(user=user.id)
+
+        if user_has_access and user_profile[0].tools_certification_date:
+            if has_tools_cert_expired(user_profile[0].tools_certification_date):
+                remove_tools_access(user)
+
+    logger.info("_remove_tools_access: End")

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -1,4 +1,5 @@
 from base64 import urlsafe_b64encode
+import calendar
 import csv
 import datetime
 import json
@@ -1362,3 +1363,10 @@ def get_tinymce_configs(configs):
             }
         )
     return tiny_mce_configs
+
+
+def has_tools_cert_expired(cert_date):
+    given_datetime = datetime.datetime.combine(cert_date, datetime.datetime.min.time())
+    total_days = 366 if calendar.isleap(datetime.date.today().year) else 365
+    one_year_ago = datetime.datetime.now() - datetime.timedelta(days=total_days)
+    return bool(one_year_ago >= given_datetime or given_datetime > datetime.datetime.now())

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -340,6 +340,12 @@ CELERY_ROUTES = {
 
 if not strtobool(env.get("DISABLE_CELERY_BEAT_SCHEDULE", "0")):
     CELERY_BEAT_SCHEDULE = {
+        "remove_tools_access_for_users_with_expired_cert": {
+            "task": "dataworkspace.apps.applications.utils.remove_tools_access_for_users_with_expired_cert",
+            # Executes every day at 5:00 a.m.
+            "schedule": crontab(hour=5, minute=0),
+            "args": (),
+        },
         "kill-idle-fargate-containers": {
             "task": "dataworkspace.apps.applications.utils.kill_idle_fargate",
             "schedule": 60 * 10,

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -34,7 +34,6 @@ from dataworkspace.apps.applications.utils import (
     sync_quicksight_permissions,
     _do_sync_s3_sso_users,
     _process_staff_sso_file,
-    has_tools_cert_expired,
     remove_tools_access_for_users_with_expired_cert,
 )
 from dataworkspace.apps.datasets.constants import UserAccessType

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -1577,7 +1577,7 @@ class TestRemoveToolsAccessForUsersWithExpiredCert:
     one_year_ago = datetime.datetime.now() - datetime.timedelta(days=total_days)
     one_day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
 
-    def setup_user_tools_cert(self, user, cert_date, codenames=permissions_codenames):
+    def setup_user_tools_cert(self, user, cert_date, codenames=[]):
         for codename in codenames:
             tools_permission = Permission.objects.get(
                 codename=codename,
@@ -1591,7 +1591,7 @@ class TestRemoveToolsAccessForUsersWithExpiredCert:
     @pytest.mark.django_db
     def test_removes_permissions_when_cert_has_expired(self):
         user = UserFactory.create()
-        self.setup_user_tools_cert(user, self.one_year_ago.date())
+        self.setup_user_tools_cert(user, self.one_year_ago.date(), self.permissions_codenames)
 
         can_start_tools = user.user_permissions.filter(
             codename__in=self.permissions_codenames
@@ -1606,7 +1606,7 @@ class TestRemoveToolsAccessForUsersWithExpiredCert:
     @pytest.mark.django_db
     def test_does_not_remove_permissions_when_cert_is_valid(self):
         user = UserFactory.create()
-        self.setup_user_tools_cert(user, self.one_day_ago.date())
+        self.setup_user_tools_cert(user, self.one_day_ago.date(), self.permissions_codenames)
 
         can_start_tools = user.user_permissions.filter(
             codename__in=self.permissions_codenames
@@ -1621,7 +1621,7 @@ class TestRemoveToolsAccessForUsersWithExpiredCert:
     @pytest.mark.django_db
     def test_does_not_effect_permissions_when_user_has_no_permissions_but_has_valid_cert(self):
         user = UserFactory.create()
-        self.setup_user_tools_cert(user, self.one_day_ago.date(), [])
+        self.setup_user_tools_cert(user, self.one_day_ago.date())
 
         can_start_tools = user.user_permissions.filter(
             codename__in=self.permissions_codenames

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -1590,23 +1590,6 @@ class TestRemoveToolsAccessForUsersWithExpiredCert:
         user.save()
 
     @pytest.mark.django_db
-    @freeze_time("2024-07-30")
-    def test_tools_cert_has_expired_when_cert_date_is_over_year_old(self):
-        assert has_tools_cert_expired(datetime.date(year=2023, month=7, day=31)) is False
-
-    @pytest.mark.django_db
-    @freeze_time("2024-07-30")
-    def test_tools_cert_has_not_expired_when_cert_date_is_less_than_a_year_old(self):
-        assert has_tools_cert_expired(datetime.date(year=2023, month=7, day=30)) is True
-
-    @pytest.mark.django_db
-    @freeze_time("2020-02-28")
-    def test_tools_cert_has_expired_when_cert_date_falls_on_a_leap_year_and_is_over_a_year_old(
-        self,
-    ):
-        assert has_tools_cert_expired(datetime.date(year=2019, month=2, day=27)) is True
-
-    @pytest.mark.django_db
     def test_removes_permissions_when_cert_has_expired(self):
         user = UserFactory.create()
         self.setup_user_tools_cert(user, self.one_year_ago.date())

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -1,4 +1,5 @@
 # pylint: disable=unspecified-encoding
+import calendar
 import datetime
 import json
 import os
@@ -33,6 +34,7 @@ from dataworkspace.apps.applications.utils import (
     sync_quicksight_permissions,
     _do_sync_s3_sso_users,
     _process_staff_sso_file,
+    remove_tools_access_for_users_with_expired_cert,
 )
 from dataworkspace.apps.datasets.constants import UserAccessType
 from dataworkspace.apps.datasets.models import ToolQueryAuditLog, ToolQueryAuditLogTable
@@ -1560,3 +1562,58 @@ class TestLongRunningQueryAlerts:
             ":rotating_light: Found 1 SQL query running for longer than 15 minutes "
             "on the datasets db."
         )
+
+
+class Test_remove_tools_access_for_users_with_expired_cert:
+
+    permissions_codenames = [
+        "start_all_applications",
+        "develop_visualisations",
+        "access_quicksight",
+        "access_appstream",
+    ]
+
+    total_days = 366 if calendar.isleap(datetime.date.today().year) else 365
+    one_year_ago = datetime.datetime.now() - datetime.timedelta(days=total_days)
+    one_day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
+
+    def setup_user_tools_cert(self, user, cert_date):
+        for codename in self.permissions_codenames:
+            tools_permission = Permission.objects.get(
+                codename=codename,
+                content_type=ContentType.objects.get_for_model(ApplicationInstance),
+            )
+            user.user_permissions.add(tools_permission)
+
+        user.profile.tools_certification_date = cert_date
+        user.save()
+
+    @pytest.mark.django_db
+    def test_removes_access_when_cert_has_expired(self):
+        user = UserFactory.create()
+        self.setup_user_tools_cert(user, self.one_year_ago.date())
+
+        can_start_tools = user.user_permissions.filter(
+            codename__in=self.permissions_codenames
+        ).exists()
+        assert can_start_tools is True
+        remove_tools_access_for_users_with_expired_cert()
+        can_start_tools = user.user_permissions.filter(
+            codename__in=self.permissions_codenames
+        ).exists()
+        assert can_start_tools is False
+
+    @pytest.mark.django_db
+    def test_does_not_remove_access_when_cert_is_valid(self):
+        user = UserFactory.create()
+        self.setup_user_tools_cert(user, self.one_day_ago.date())
+
+        can_start_tools = user.user_permissions.filter(
+            codename__in=self.permissions_codenames
+        ).exists()
+        assert can_start_tools is True
+        remove_tools_access_for_users_with_expired_cert()
+        can_start_tools = user.user_permissions.filter(
+            codename__in=self.permissions_codenames
+        ).exists()
+        assert can_start_tools is True

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -1566,18 +1566,18 @@ class TestLongRunningQueryAlerts:
 
 class TestRemoveToolsAccessForUsersWithExpiredCert:
 
-    permissions_codenames = [
+    permissions_codenames = (
         "start_all_applications",
         "develop_visualisations",
         "access_quicksight",
         "access_appstream",
-    ]
+    )
 
     total_days = 366 if calendar.isleap(datetime.date.today().year) else 365
     one_year_ago = datetime.datetime.now() - datetime.timedelta(days=total_days)
     one_day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
 
-    def setup_user_tools_cert(self, user, cert_date, codenames=[]):
+    def setup_user_tools_cert(self, user, cert_date, codenames=()):
         for codename in codenames:
             tools_permission = Permission.objects.get(
                 codename=codename,

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -1601,7 +1601,9 @@ class TestRemoveToolsAccessForUsersWithExpiredCert:
 
     @pytest.mark.django_db
     @freeze_time("2020-02-28")
-    def test_tools_cert_has_expired_when_cert_date_falls_on_a_leap_year_and_is_over_a_year_old(self):
+    def test_tools_cert_has_expired_when_cert_date_falls_on_a_leap_year_and_is_over_a_year_old(
+        self,
+    ):
         assert has_tools_cert_expired(datetime.date(year=2019, month=2, day=27)) is True
 
     @pytest.mark.django_db

--- a/dataworkspace/dataworkspace/tests/core/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/core/test_utils.py
@@ -328,3 +328,10 @@ class TestHasToolsCertExpired:
         self,
     ):
         assert has_tools_cert_expired(datetime.date(year=2019, month=2, day=27)) is True
+
+    @pytest.mark.django_db
+    @freeze_time("2020-02-28")
+    def test_cert_date_has_not_expired_when_date_falls_on_a_leap_year_and_is_less_then_a_year_old(
+        self,
+    ):
+        assert has_tools_cert_expired(datetime.date(year=2019, month=2, day=28)) is False

--- a/dataworkspace/dataworkspace/tests/core/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/core/test_utils.py
@@ -1,7 +1,7 @@
-from freezegun import freeze_time
 import datetime
 import re
 import time
+from freezegun import freeze_time
 
 import mock
 import psycopg2


### PR DESCRIPTION
### Description of change

Ticket [DT-2190](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-2190)

This change adds a new Celery task that checks if any users tools certificates have expired. If they have, then a function runs that removes all tools access. This task will run every morning at 5:00am.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?

[DT-2190]: https://uktrade.atlassian.net/browse/DT-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ