### PR TITLE
feature/decrease-redis-cache-expiry-to-log-users-out-quicker

### DIFF
--- a/dataworkspace/proxy_session.py
+++ b/dataworkspace/proxy_session.py
@@ -37,7 +37,7 @@ from aiohttp import web
 COOKIE_MAX_AGE = 60 * 60 * 10
 
 REDIS_KEY_PREFIX = "data_workspace_session___cookie"
-REDIS_MAX_AGE = 60 * 60 * 9
+REDIS_MAX_AGE = 60 * 15  # 15 minutes
 
 SESSION_KEY = "SESSION"
 


### PR DESCRIPTION
### Description of change
The current user session is valid for 9 hours when stored in redis, to avoid repeatedly calling the SSO api. This can cause a situation where a user account has been deactivated in sso, however their data workspace session continues until the 9 hour limit is reached

This PR reduces the session limit to be 15 minutes, which balances the need to avoid hitting the SSO api on every request with the need to remove deactivated accounts quickly

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?