### PR TITLE
Classification check page and tests

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/add_table/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/urls.py
@@ -4,7 +4,7 @@ from dataworkspace.apps.accounts.utils import login_required
 from dataworkspace.apps.datasets.add_table.views import (
     AddTableView,
     TableSchemaView,
-    ClassificationCheck,
+    ClassificationCheckView,
 )
 
 
@@ -21,7 +21,7 @@ urlpatterns = [
     ),
     path(
         "<str:schema>/classification-check",
-        login_required(ClassificationCheck.as_view()),
+        login_required(ClassificationCheckView.as_view()),
         name="classification-check",
     ),
 ]

--- a/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
@@ -49,10 +49,8 @@ class TableSchemaView(FormView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-
         dataset = find_dataset(self.kwargs["pk"], self.request.user)
         schemas = self.get_schemas(dataset)
-
         ctx["model"] = dataset
         ctx["schema"] = schemas[0]
         ctx["is_multiple_schemas"] = len(schemas) > 1
@@ -64,7 +62,7 @@ class TableSchemaView(FormView):
         clean_data = form.cleaned_data
         schema = clean_data["schema"]
         return HttpResponseRedirect(
-            reverse("datasets:add_table:classification-check", args={self.kwargs["pk"], schema})
+            reverse("datasets:add_table:classification-check", args=(self.kwargs["pk"], schema))
         )
 
 

--- a/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
@@ -68,5 +68,16 @@ class TableSchemaView(FormView):
         )
 
 
-class ClassificationCheck(TemplateView):
+class ClassificationCheckView(TemplateView):
     template_name = "datasets/add_table/classification_check.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        dataset = find_dataset(self.kwargs["pk"], self.request.user)
+        ctx["model"] = dataset
+        ctx["classification"] = (
+            dataset.get_government_security_classification_display() or "Unclassified"
+        ).title()
+        ctx["backlink"] = reverse("datasets:add_table:table-schema", args={self.kwargs["pk"]})
+        ctx["nextlink"] = ""
+        return ctx

--- a/dataworkspace/dataworkspace/templates/datasets/add_table/classification_check.html
+++ b/dataworkspace/dataworkspace/templates/datasets/add_table/classification_check.html
@@ -1,18 +1,28 @@
 {% extends '_main.html' %}
-
-
 {% block page_title %}Add Table - {{ model.name }} - {{ block.super }}{% endblock %}
-
 {% if backlink %}
-{% block go_back %}
-<a href="{{ backlink }}" class="govuk-back-link">Back</a>
-{% endblock %}
+  {% block go_back %}
+    <a href="{{ backlink }}" class="govuk-back-link">Back</a>
+  {% endblock %}
 {% endif %}
-
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Check your upload is compatible with the catalogue item</h1>
+
+        <h2 class="govuk-heading-m">The security classification of the catalogue item is '{{ classification }}'</h2>
+
+        <p class="govuk-body">You must not add a table that would change the security classification of the catalogue item you're adding to.</p>
+        <p class="govuk-body">If you need to change the security classification of this catalogue item,
+            <a class="govuk-link" href="/contact-us/" target="_blank">contact us (opens in a new tab)</a>.
+        </p> 
+        <p class="govuk-body">By clicking 'continue', you're confirming your upload:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>has a consistent security classification with the catalogue item</li>
+            <li>relates to the catalogue item</li>
+            <li>can be accessed by users who already have access to other tables in the catalogue item</li>
+        </ul>
+        <a class="govuk-button" href="{{ nextlink }}">Continue</a>
     </div>
 </div>
 {% endblock %}

--- a/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
@@ -17,6 +17,7 @@ class TestAddTable(TestCase):
             published=True,
             user_access_type=UserAccessType.REQUIRES_AUTHORIZATION,
             information_asset_owner=self.user,
+            government_security_classification=2,
         )
         self.source = factories.SourceTableFactory.create(
             dataset=self.dataset, schema="test", table="table1"
@@ -164,3 +165,33 @@ class TestAddTable(TestCase):
 
         schemas = list(radio_names)
         assert len(schemas) == 2
+
+    def test_classification_check_page(self):
+        response = self.client.get(
+            reverse(
+                "datasets:add_table:classification-check",
+                kwargs={"pk": self.dataset.id, "schema": self.source.schema},
+            ),
+        )
+
+        soup = BeautifulSoup(response.content.decode(response.charset))
+        header_one = soup.find("h1")
+        header_two = soup.find("h2")
+        paragraph = soup.find("p")
+        title = soup.find("title")
+        header_one_text = header_one.contents
+        header_two_text = header_two.contents
+        paragraph_text = paragraph.contents
+        title_text = title.contents[0]
+
+        assert response.status_code == 200
+        assert f"Add Table - {self.dataset.name} - Data Workspace" in title_text
+        assert "Check your upload is compatible with the catalogue item" in header_one_text
+        assert (
+            "The security classification of the catalogue item is 'Official-Sensitive'"
+            in header_two_text
+        )
+        assert (
+            "You must not add a table that would change the security classification of the catalogue item you're adding to."
+            in paragraph_text
+        )


### PR DESCRIPTION
### Description of change
Part of the Add Table flow for the security classification check page.

To test:
Go to a data catalogue page and add `/add-table` to the url (removing #{dataset-name} if there)
Follow the flow and you should get to this page. The header should display the security classification of the dataset

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?