### PR TITLE
feat: show pipeline type and platform on pipelines page

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
+++ b/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
@@ -67,6 +67,12 @@
                       <strong class="govuk-tag govuk-tag--grey" style="font-size: 0.7em" title="{{ object.get_schedule_display }}">
                         {{ object.schedule }}
                       </strong>
+                      <strong class="govuk-tag govuk-tag--grey" style="font-size: 0.7em" title="{{ object.type }}">
+                        {{ object.type }}
+                      </strong><br>
+                      <strong class="govuk-tag govuk-tag--grey" style="font-size: 0.7em" title="{{ object.get_data_flow_platform_display }}">
+                        {{ object.get_data_flow_platform_display }}
+                      </strong>
                     </dd>
                 </div>
                 {% endfor %}


### PR DESCRIPTION
### Description of change

This adds the pipeline type (so "Sharepoint" or "SQL") and the platform ("GOV.UK PaaS" or "Data Workspace AWS") to each pipeline in the /pipelines page.

This is to primarily help the migration off GOV.UK PaaS, so we know what is done and what's left to do, and is a temporary change. However, the pipeline type is apparently useful to see, so that might be left longer term.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?