### PR TITLE
Remove tags for QS and Superset in Tools

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils_tools.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils_tools.py
@@ -58,8 +58,6 @@ def get_groups(request):
                     help_link=None,
                     link=reverse("applications:quicksight_redirect"),
                     has_access=request.user.has_perm("applications.access_quicksight"),
-                    tag="Recommended",
-                    tag_extra_css_class="govuk-tag--blue",
                 ),
                 ToolsViewModel(
                     name="Superset",
@@ -69,8 +67,6 @@ def get_groups(request):
                     help_link=None,
                     link=reverse("applications:superset_redirect"),
                     has_access=request.user.has_perm("applications.start_all_applications"),
-                    tag="New",
-                    tag_extra_css_class="govuk-tag--green",
                 ),
             ],
             "group_description": "create dashboards",


### PR DESCRIPTION
### Description of change

This PR removes the tags from the Tools page for Quicksight and Superset. This is because Superset is no longer new and Quicksight is not so strongly recommended (it's expensive and Superset is stable enough for more general use)

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?