### PR TITLE
Reduce connection timeout frequency by avoiding running SET ROLE for contexts that can't make objects

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -292,11 +292,20 @@ def new_private_database_credentials(
                 )
 
             # Make it so by default, objects created by the user are owned by the role
-            cur.execute(
-                sql.SQL("ALTER USER {} SET ROLE {};").format(
-                    sql.Identifier(db_user), sql.Identifier(db_role)
+            # This seems to have a horrible performance impact on connecting, so we don't do it for
+            # contexts that can't create objects. The reason for the performance impact on
+            # connecting is currently unknown, but seems to be related to the number of other roles
+            # granted
+            if not (
+                db_user.endswith("_qs")
+                or db_user.endswith("_superset")
+                or db_user.endswith("_explorer")
+            ):
+                cur.execute(
+                    sql.SQL("ALTER USER {} SET ROLE {};").format(
+                        sql.Identifier(db_user), sql.Identifier(db_role)
+                    )
                 )
-            )
 
             # Give the user reasonable timeouts
             cur.execute(


### PR DESCRIPTION
### Description of change

In our PostgreSQL permissions setup, each tool has a temporary database user that is granted the permanent database role of the person launching the tool. We also SET ROLE of the temporary user to the permanent role, so that objects created by the temporary user are then owned by the permanent role.

However, this seems to have performance implications on connecting:

- It increases the "best case" connection time from 0.03s to 0.06s.
- Which doesn't matter too much, but it also increases the frequency of "worst case" connection times, when connection takes about 40 seconds.

So this change makes it so we avoid running SET ROLE for the environments where it's not possible to make objects: QuickSight, Superset and Data Explorer.

This doesn't appear to completely remove "worst case" connection times, but it is hopefully a small step towards that.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?