### PR TITLE
feat/DT-2059 Add Table: Upload CSV

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/add_table/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/forms.py
@@ -1,13 +1,17 @@
 import re
 from django.forms import ValidationError
+from django.core.validators import FileExtensionValidator
 from dataworkspace.forms import (
     GOVUKDesignSystemCharField,
+    GOVUKDesignSystemFileField,
+    GOVUKDesignSystemFileInputWidget,
     GOVUKDesignSystemForm,
     GOVUKDesignSystemRadioField,
     GOVUKDesignSystemRadiosWidget,
     GOVUKDesignSystemTextWidget,
     GOVUKDesignSystemTextCharCountWidget,
 )
+from dataworkspace.apps.core.storage import malware_file_validator
 
 
 class TableSchemaForm(GOVUKDesignSystemForm):
@@ -89,3 +93,36 @@ class TableNameForm(GOVUKDesignSystemForm):
         elif "record" in table_name:
             raise ValidationError("Table name cannot contain the word 'record'")
         return table_name
+
+
+
+class UploadCSVForm(GOVUKDesignSystemForm):
+
+    def clean_csv_file(self):
+        cleaned_data = super().clean()
+        csv_name = cleaned_data["csv_file"]._name.replace(".csv", "")
+        if bool(re.search(r"[^A-Za-z_-]", csv_name)):
+            raise ValidationError(
+                "File name cannot contain special characters apart from underscores and hyphens"
+            )
+        return cleaned_data["csv_file"]
+
+    csv_file = GOVUKDesignSystemFileField(
+        required=True,
+        label="Upload a file",
+        widget=GOVUKDesignSystemFileInputWidget(
+            label_is_heading=True,
+            heading="p",
+            heading_class="govuk-body",
+            show_selected_file=True,
+            attrs={"accept": "text/csv"},
+        ),
+        validators=[
+            FileExtensionValidator(allowed_extensions=["csv"]),
+            malware_file_validator,
+        ],
+        error_messages={
+            "required": "Select a CSV",
+            "invalid_extension": "Invalid file type. Only CSV files are currently supported.",
+        },
+    )

--- a/dataworkspace/dataworkspace/apps/datasets/add_table/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/forms.py
@@ -95,7 +95,6 @@ class TableNameForm(GOVUKDesignSystemForm):
         return table_name
 
 
-
 class UploadCSVForm(GOVUKDesignSystemForm):
 
     def clean_csv_file(self):
@@ -112,8 +111,7 @@ class UploadCSVForm(GOVUKDesignSystemForm):
         label="Upload a file",
         widget=GOVUKDesignSystemFileInputWidget(
             label_is_heading=True,
-            heading="p",
-            heading_class="govuk-body",
+            heading_class="govuk-label",
             show_selected_file=True,
             attrs={"accept": "text/csv"},
         ),

--- a/dataworkspace/dataworkspace/apps/datasets/add_table/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/urls.py
@@ -7,6 +7,7 @@ from dataworkspace.apps.datasets.add_table.views import (
     TableSchemaView,
     ClassificationCheckView,
     DescriptiveNameView,
+    UploadCSVView,
 )
 
 
@@ -35,5 +36,10 @@ urlpatterns = [
         "<str:schema>/<str:descriptive_name>/table-name",
         login_required(TableNameView.as_view()),
         name="table-name",
+    ),
+    path(
+        "<str:schema>/<str:descriptive_name>/<str:table_name>/upload-csv",
+        login_required(UploadCSVView.as_view()),
+        name="upload-csv",
     ),
 ]

--- a/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
@@ -16,6 +16,7 @@ from dataworkspace.apps.datasets.add_table.forms import (
 from dataworkspace.apps.core.boto3_client import get_s3_client
 from dataworkspace.apps.core.utils import get_s3_prefix
 
+
 class AddTableView(DetailView):
     template_name = "datasets/add_table/about_this_service.html"
 

--- a/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
@@ -183,7 +183,7 @@ class UploadCSVView(FormView):
     def _get_file_upload_key(self, file_name, pk):
         return os.path.join(
             get_s3_prefix(str(self.request.user.profile.sso_id)),
-            "_add_table_uploads",  # will need to change
+            "_add_table_uploads",
             str(pk),
             file_name,
         )

--- a/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
@@ -1,14 +1,20 @@
+import os
+import uuid
+from aiohttp import ClientError
+from django.conf import settings
 from django.urls import reverse
 from django.views.generic import DetailView, FormView, TemplateView
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpResponseServerError
 
 from dataworkspace.apps.datasets.utils import find_dataset
 from dataworkspace.apps.datasets.add_table.forms import (
     TableNameForm,
     TableSchemaForm,
     DescriptiveNameForm,
+    UploadCSVForm,
 )
-
+from dataworkspace.apps.core.boto3_client import get_s3_client
+from dataworkspace.apps.core.utils import get_s3_prefix
 
 class AddTableView(DetailView):
     template_name = "datasets/add_table/about_this_service.html"
@@ -155,11 +161,70 @@ class TableNameView(FormView):
         return ctx
 
     def form_valid(self, form):
-        # table_name = form.cleaned_data["table_name"]
+        table_name = form.cleaned_data["table_name"]
         return HttpResponseRedirect(
-            ("/")
-            # reverse(
-            #     "datasets:add_table:{NEW_PAGE}",
-            #     args=(self.kwargs["pk"], self.kwargs["schema"], self.kwargs["descriptive_name"], table_name),
-            # )
+            reverse(
+                "datasets:add_table:upload-csv",
+                args=(
+                    self.kwargs["pk"],
+                    self.kwargs["schema"],
+                    self.kwargs["descriptive_name"],
+                    table_name,
+                ),
+            )
+        )
+
+
+class UploadCSVView(FormView):
+    template_name = "datasets/add_table/upload_csv.html"
+    form_class = UploadCSVForm
+
+    def _get_file_upload_key(self, file_name, pk):
+        return os.path.join(
+            get_s3_prefix(str(self.request.user.profile.sso_id)),
+            "_add_table_uploads",  # will need to change
+            str(pk),
+            file_name,
+        )
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        dataset = find_dataset(self.kwargs["pk"], self.request.user)
+        ctx["model"] = dataset
+        ctx["backlink"] = reverse(
+            "datasets:add_table:table-name",
+            args=(self.kwargs["pk"], self.kwargs["schema"], self.kwargs["descriptive_name"]),
+        )
+        return ctx
+
+    def form_valid(self, form):
+        csv_file = form.cleaned_data["csv_file"]
+        client = get_s3_client()
+        file_name = f"{csv_file.name}!{uuid.uuid4()}"
+        key = self._get_file_upload_key(file_name, self.kwargs["pk"])
+        csv_file.seek(0)
+        try:
+            client.put_object(
+                Body=csv_file,
+                Bucket=settings.NOTEBOOKS_BUCKET,
+                Key=key,
+            )
+        except ClientError as ex:
+            # pylint: disable=raise-missing-from
+            # pylint: disable=no-member
+            return HttpResponseServerError(
+                "Error saving file: {}".format(ex.response["Error"]["Message"])
+            )
+
+        return HttpResponseRedirect(
+            reverse(
+                "datasets:add_table:data-types",
+                args=(
+                    self.kwargs["pk"],
+                    self.kwargs["schema"],
+                    self.kwargs["descriptive_name"],
+                    self.kwargs["table_name"],
+                ),
+            )
+            + f"?file={file_name}"
         )

--- a/dataworkspace/dataworkspace/templates/datasets/add_table/upload_csv.html
+++ b/dataworkspace/dataworkspace/templates/datasets/add_table/upload_csv.html
@@ -1,0 +1,38 @@
+{% extends '_main.html' %}
+
+{% block page_title %}
+Add Table - {{ model.name }} - {{ block.super }}{% endblock %}
+{% if backlink %}
+{% block go_back %}
+<a href="{{ backlink }}" class="govuk-back-link">Back</a>
+{% endblock %}
+{% endif %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        {% include 'design_system/error_summary.html' with form=form %}
+        <h1 class="govuk-heading-xl">Upload CSV</h1>
+        <h2 class="govuk-heading-l">Before you upload your CSV</h2>
+            <p class="govuk-body">Check your CSV against each of the below points. This can help you avoid common issues when the table is being built.</p>
+            <h2 class="govuk-heading-m">Check your files format and name</h2>
+            <p class="govuk-body">Check that:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>the file has more than one row</li>
+                <li>there are no special characters in the file name (e.g. /*? ) apart from underscores and hyphens</li>
+                <li>Google Sheets documents are downloaded as a standard CSV file</li>
+            </ul>
+            <h2 class="govuk-heading-m">Check your formatting in Excel</h2>
+            <p class="govuk-body">Check that:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>any data you want to set as a date is in the format yyyy-mm-dd</li>
+                <li>ensure columns are formatted as ‘General’ - integer and numeric fields may not upload otherwise</li>
+            </ul>
+            <form method="POST" novalidate enctype="multipart/form-data">
+                {% csrf_token %}
+                {{ form.csv_file }}
+                <button class="govuk-button" type="submit">Continue</button>
+            </form>
+    </div>
+</div>
+{% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/add_table/upload_csv.html
+++ b/dataworkspace/dataworkspace/templates/datasets/add_table/upload_csv.html
@@ -24,7 +24,7 @@ Add Table - {{ model.name }} - {{ block.super }}{% endblock %}
             </ul>
             <h2 class="govuk-heading-m">Check your formatting in Excel</h2>
             <p class="govuk-body">Check that:</p>
-            <ul class="govuk-list govuk-list--bullet">
+            <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
                 <li>any data you want to set as a date is in the format yyyy-mm-dd</li>
                 <li>ensure columns are formatted as ‘General’ - integer and numeric fields may not upload otherwise</li>
             </ul>

--- a/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
@@ -500,6 +500,14 @@ class TestUploadCSVPage(TestCase):
             for bullet_point in bullet_points
             for li in bullet_point.find_all("li")
         ]
+        bullet_points_two = soup.find_all(
+            "ul", class_="govuk-list govuk-list--bullet govuk-!-margin-bottom-6"
+        )
+        bullet_point_text_two = [
+            li.get_text(strip=True)
+            for bullet_point_two in bullet_points_two
+            for li in bullet_point_two.find_all("li")
+        ]
 
         assert response.status_code == 200
         assert f"/datasets/{self.dataset.id}" in backlink
@@ -511,7 +519,7 @@ class TestUploadCSVPage(TestCase):
             "Check your CSV against each of the below points. This can help you avoid common issues when the table is being built."
             in paragraph_one_text
         )
-        assert len(bullet_point_text) == 5
+        assert len(bullet_point_text) + len(bullet_point_text_two) == 5
 
     def test_csv_upload_fails_when_it_contains_special_chars(self):
 

--- a/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
@@ -3,6 +3,7 @@ import pytest
 from bs4 import BeautifulSoup
 from django.urls import reverse
 from django.test import Client
+from django.core.files.uploadedfile import SimpleUploadedFile
 from dataworkspace.tests import factories
 from dataworkspace.apps.datasets.constants import UserAccessType
 from dataworkspace.tests.common import get_http_sso_data
@@ -455,3 +456,114 @@ class TestTableNamePage(TestCase):
         assert response.status_code == 200
         assert "There is a problem" in error_header_text
         assert "Table name already in use" in error_message_text
+
+
+
+
+@pytest.mark.django_db
+class TestUploadCSVPage(TestCase):
+    def setUp(self):
+        self.user = factories.UserFactory.create(is_superuser=False)
+        self.client = Client(**get_http_sso_data(self.user))
+        self.dataset = factories.MasterDataSetFactory.create(
+            published=True,
+            user_access_type=UserAccessType.REQUIRES_AUTHORIZATION,
+            information_asset_owner=self.user,
+            government_security_classification=2,
+        )
+        self.source = factories.SourceTableFactory.create(
+            dataset=self.dataset, schema="test", table="table_one", name="table_one"
+        )
+        self.descriptive_name = "my_table"
+        self.table_name = "my_table_name"
+
+    def test_upload_csv_page(self):
+        response = self.client.post(
+            reverse(
+                "datasets:add_table:upload-csv",
+                kwargs={
+                    "pk": self.dataset.id,
+                    "schema": self.source.schema,
+                    "descriptive_name": self.descriptive_name,
+                    "table_name": self.table_name,
+                },
+            ),
+        )
+
+        soup = BeautifulSoup(response.content.decode(response.charset))
+        title_text = soup.find("title").get_text(strip=True)
+        backlink = soup.find("a", {"class": "govuk-back-link"}).get("href")
+        header_one_text = soup.find("h1", class_="govuk-heading-xl").get_text(strip=True)
+        header_two_text = soup.find("h2", class_="govuk-heading-l").get_text(strip=True)
+        paragraph_one_text = soup.find("p").get_text(strip=True)
+        bullet_points = soup.find_all("ul", class_="govuk-list govuk-list--bullet")
+        bullet_point_text = [
+            li.get_text(strip=True)
+            for bullet_point in bullet_points
+            for li in bullet_point.find_all("li")
+        ]
+
+        assert response.status_code == 200
+        assert f"/datasets/{self.dataset.id}" in backlink
+        assert response.status_code == 200
+        assert f"Add Table - {self.dataset.name} - Data Workspace" in title_text
+        assert "Upload CSV" in header_one_text
+        assert "Before you upload your CSV" in header_two_text
+        assert (
+            "Check your CSV against each of the below points. This can help you avoid common issues when the table is being built."
+            in paragraph_one_text
+        )
+        assert len(bullet_point_text) == 5
+
+    def test_csv_upload_fails_when_it_contains_special_chars(self):
+
+        file1 = SimpleUploadedFile(
+            "sp£c!al-ch@r$.csv",
+            b"id,name\r\nA1,test1\r\nA2,test2\r\n",
+            content_type="text/csv",
+        )
+
+        response = self.client.post(
+            reverse(
+                "datasets:add_table:upload-csv",
+                kwargs={
+                    "pk": self.dataset.id,
+                    "schema": self.source.schema,
+                    "descriptive_name": self.descriptive_name,
+                    "table_name": self.table_name,
+                },
+            ),
+            data={"csv_file": file1},
+        )
+
+        soup = BeautifulSoup(response.content.decode(response.charset))
+        error_message_text = (
+            soup.find("ul", class_="govuk-list govuk-error-summary__list").find("a").contents
+        )
+        assert response.status_code == 200
+        assert (
+            "File name cannot contain special characters apart from underscores and hyphens"
+            in error_message_text
+        )
+
+    def test_csv_upload_fails_when_no_file_is_selected(self):
+
+        response = self.client.post(
+            reverse(
+                "datasets:add_table:upload-csv",
+                kwargs={
+                    "pk": self.dataset.id,
+                    "schema": self.source.schema,
+                    "descriptive_name": self.descriptive_name,
+                    "table_name": self.table_name,
+                },
+            ),
+            data={"csv_file": ""},
+        )
+
+        soup = BeautifulSoup(response.content.decode(response.charset))
+        error_message_text = (
+            soup.find("ul", class_="govuk-list govuk-error-summary__list").find("a").contents
+        )
+        assert response.status_code == 200
+        assert "Select a CSV" in error_message_text

--- a/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
@@ -458,8 +458,6 @@ class TestTableNamePage(TestCase):
         assert "Table name already in use" in error_message_text
 
 
-
-
 @pytest.mark.django_db
 class TestUploadCSVPage(TestCase):
     def setUp(self):


### PR DESCRIPTION
This is the upload CSV page for the service of adding a table to an existing catalogue page. This work includes validation:

Given a user hasn’t selected a CSV to upload and they press the continue button then an error message should appear above the text input and an error summary should appear at the top of the page saying “Select a CSV”
Given a user has selected a CSV that contains special characters in the name and they press the continue button then an error message should appear above the text input and an error summary should appear at the top of the page saying “File name cannot contain special characters apart from underscores and hyphens

**How to Test**

- Navigate to /datasets
- Add /add-table to the end of the dataset ID
- Click through the flow to get to 'Upload CSV'
- Try uploading no file then try uploading a .csv file with special characters, both should display the error messages above.