### PR TITLE
fix/DT-2200-change-date-self-certified-to-training-date

### DIFF
--- a/dataworkspace/dataworkspace/apps/accounts/admin.py
+++ b/dataworkspace/dataworkspace/apps/accounts/admin.py
@@ -111,8 +111,8 @@ class AppUserEditForm(forms.ModelForm):
         queryset=None,
     )
     certificate_date = forms.DateField(
-        label="Date self-certified",
-        help_text="Date that user last self-certified for tools access",
+        label="Training completion date",
+        help_text="Date that user last completed training for self-certified tool access",
         required=False,
     )
 


### PR DESCRIPTION
### Description of change

Changed 'Date self-certified' to 'Training date' for the date field on the users page in Django admin.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?