### PR TITLE
Specify per env protol for connecting to Arango

### DIFF
--- a/.envs/sample.env
+++ b/.envs/sample.env
@@ -81,6 +81,7 @@ ARANGO_DB__HOST=data-workspace-arango
 ARANGO_DB__PASSWORD=arango
 ARANGO_DB__PORT=8529
 ARANGO_DB__USER=root
+ARANGO_DB__PROTOCOL=http
 
 ZENDESK_EMAIL=test@test.com
 # ZENDESK_SUBDOMAIN just requires the subdomain part not the full url

--- a/.envs/test.env
+++ b/.envs/test.env
@@ -70,6 +70,7 @@ ARANGO_DB__HOST=data-workspace-arango
 ARANGO_DB__PASSWORD=arango
 ARANGO_DB__PORT=8529
 ARANGO_DB__USER=root
+ARANGO_DB__PROTOCOL=http
 
 ALLOWED_HOSTS='dataworkspace.test'
 

--- a/dataworkspace/dataworkspace/apps/arangodb/utils.py
+++ b/dataworkspace/dataworkspace/apps/arangodb/utils.py
@@ -41,7 +41,9 @@ def new_private_arangodb_credentials(
 
     try:
         logger.info("Connecting as root to ArangoDB")
-        client = ArangoClient(hosts=f"http://{database_data['HOST']}:{database_data['PORT']}")
+        client = ArangoClient(
+            hosts=f"{database_data['PROTOCOL']}://{database_data['HOST']}:{database_data['PORT']}"
+        )
         sys_db = client.db(
             "_system", username="root", password=database_data["PASSWORD"], verify=True
         )
@@ -108,7 +110,9 @@ def _do_delete_unused_arangodb_users():
 
     logger.info("delete_unused_arangodb_users: finding temporary database users")
     try:
-        client = ArangoClient(hosts=f"http://{database_data['HOST']}:{database_data['PORT']}")
+        client = ArangoClient(
+            hosts=f"{database_data['PROTOCOL']}://{database_data['HOST']}:{database_data['PORT']}"
+        )
         sys_db = client.db(
             "_system", username="root", password=database_data["PASSWORD"], verify=True
         )


### PR DESCRIPTION
### Description of change
This PR specifies the protocl through which ArangoDb should be communicated. This is HTTP in local/test environments and HTTPS remote environments in AWS, given the difficulty of using HTTPS locally

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?