### PR TITLE
feat/DT-2246: Remove visualisation tool access from self cert

### DIFF
--- a/dataworkspace/dataworkspace/apps/request_access/views.py
+++ b/dataworkspace/dataworkspace/apps/request_access/views.py
@@ -300,7 +300,6 @@ class SelfCertifyView(FormView):
 
         permission_codenames = [
             "start_all_applications",
-            "develop_visualisations",
             "access_quicksight",
         ]
         content_type = ContentType.objects.get_for_model(ApplicationInstance)

--- a/dataworkspace/dataworkspace/tests/request_access/test_views.py
+++ b/dataworkspace/dataworkspace/tests/request_access/test_views.py
@@ -578,7 +578,11 @@ class TestSelfCertify(TestCase):
         self.user.refresh_from_db()
         user_permissions = self.user.user_permissions.all()
 
-        assert user_permissions.count() == 3
+        assert user_permissions[0].name == "Can access AWS QuickSight"
+        assert user_permissions[0].codename == "access_quicksight"
+        assert user_permissions[1].name == "Can start all applications"
+        assert user_permissions[1].codename == "start_all_applications"
+        assert user_permissions.count() == 2
         assert response.status_code == 302
 
     def test_form_valid_redirects_to_tools_page(self):


### PR DESCRIPTION
### Description of change

Ticket [DT-2246](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-2246)

This change stops the self certify flow from allowing users to access the visualisation tools. There are no visual frontend changes. All this does is NOT check the "Can develop visualisations" box in admin against the users profile.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?

[DT-2246]: https://uktrade.atlassian.net/browse/DT-2246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ