### PR TITLE
bugfix/use-30-minutes-for-cache

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -1435,10 +1435,12 @@ def _do_sync_s3_sso_users():
         logger.info("sync_s3_sso_users: Deleting keys %s", delete_keys)
         bucket.delete_objects(Delete={"Objects": delete_keys})
 
-        # At the end of the loop set the cache
-        cache.set("s3_sso_sync_last_published", new_last_processed)
     else:
         logger.info("sync_s3_sso_users: No files to process")
+
+    # Always reset the cache
+    logger.info("sync_s3_sso_users: New last_published date for cache %s", new_last_processed)
+    cache.set("s3_sso_sync_last_published", new_last_processed, timeout=30 * 60)  # 30 minutes
 
 
 def fetch_visualisation_log_events(log_group, log_stream):


### PR DESCRIPTION
### Description of change
The default cache timeout is 2 minutes, and this task runs every 15 minutes which means the cache from the last task run is missing. Increasing to 30 minutes instead of the default of 2 minutes will fix this. 

Also, update the cache on every run instead of just when files are found to keep the cache value available to the next run
### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?