### PR TITLE
chore: remove staging from the production pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,31 +77,6 @@ pipeline {
       }
     }
 
-    stage('release: staging') {
-      when {
-          expression {
-              milestone label: "release-staging"
-              input message: 'Deploy to staging?'
-              return true
-          }
-          beforeAgent true
-      }
-
-      parallel {
-        stage('release: data-workspace') {
-          steps {
-            ecs_pipeline_admin("data-workspace-staging", params.GIT_COMMIT)
-          }
-        }
-        stage('release: data-workspace-celery') {
-          steps {
-            ecs_pipeline_celery("data-workspace-staging", params.GIT_COMMIT)
-          }
-        }
-      }
-    }
-
-
     stage('release: prod') {
       when {
           expression {


### PR DESCRIPTION
### Description of change
This change just removes staging from the production pipeline. We now have a dedicated staging pipeline so we don't need this anymore.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?