### PR TITLE
feat: add data cuts endpoint to expose custom sql

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
@@ -6,6 +6,7 @@ from dataworkspace.apps.datasets.models import (
     SourceTable,
     ToolQueryAuditLog,
     ToolQueryAuditLogTable,
+    CustomDatasetQuery,
 )
 
 _PURPOSES = {
@@ -106,4 +107,18 @@ class ToolQueryAuditLogSerializer(serializers.ModelSerializer):
             "rolename",
             "timestamp",
             "tables",
+        ]
+
+
+class DataCutSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = CustomDatasetQuery
+        fields = [
+            "id",
+            "name",
+            "dataset",
+            "created_date",
+            "modified_date",
+            "query",
         ]

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/urls.py
@@ -29,4 +29,9 @@ urlpatterns = [
         views.ToolQueryAuditLogViewSet.as_view({"get": "list"}),
         name="tool-query-audit-logs",
     ),
+    path(
+        "data-cuts",
+        views.DataCutViewSet.as_view({"get": "list"}),
+        name="data-cuts",
+    ),
 ]

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
@@ -33,10 +33,12 @@ from dataworkspace.apps.datasets.models import (
     ToolQueryAuditLog,
     VisualisationCatalogueItem,
     ReferenceDatasetField,
+    CustomDatasetQuery,
 )
 from dataworkspace.apps.api_v1.datasets.serializers import (
     CatalogueItemSerializer,
     ToolQueryAuditLogSerializer,
+    DataCutSerializer,
 )
 from dataworkspace.apps.datasets.data_dictionary.service import DataDictionaryService
 
@@ -520,3 +522,16 @@ def data_dictionary_api_view_GET(request, source_uuid):
         ],
     }
     return Response(response, status=status.HTTP_200_OK)
+
+
+class DataCutViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint to list data cut items for consumption by data flow.
+    """
+
+    queryset = CustomDatasetQuery.objects.all()
+
+    serializer_class = DataCutSerializer
+    # PageNumberPagination is used instead of CursorPagination
+    # as filters cannot be applied to a union-ed queryset.
+    pagination_class = PageNumberPagination


### PR DESCRIPTION
### Description of change

Added v1 API endpoint to expose the custom sql generating data cuts. This is part of larger work to build a pipeline to ingest these into Data Workspace for greater visibility to our users.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Have E2E tests been added to cover any React changes?
* [x] Have Accessibility tests been added to cover any React changes?