### PR TITLE
fix/DT-2041: Update database query to stop other environments breaking

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/views.py
@@ -502,7 +502,7 @@ class AddTableSuccessView(BaseAddTableTemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         dataset = find_dataset(self.kwargs["pk"], self.request.user)
-        database = Database.objects.get_or_create(memorable_name="datasets_1")[0]
+        database = Database.objects.filter(memorable_name__contains="datasets").first()
         source_table, _ = SourceTable.objects.get_or_create(
             schema=self._get_query_parameters()["schema"],
             dataset=dataset,

--- a/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
@@ -738,6 +738,7 @@ class TestDataTypesView(TestCase):
 @pytest.mark.django_db
 class TestAddTableConfirmation(TestCase):
     def setUp(self):
+        self.database = factories.DatabaseFactory.create(memorable_name="datasets_1")
         self.user = factories.UserFactory.create(is_superuser=False)
         self.client = Client(**get_http_sso_data(self.user))
         self.dataset = factories.MasterDataSetFactory.create(


### PR DESCRIPTION
### Description of change

Ticket [DT-2295](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-2295)

This change removes any assumptions that the database in use is always called "datasets_1". We also shouldn't try to create this if it doesn't exist.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?

[DT-2295]: https://uktrade.atlassian.net/browse/DT-2295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ