### PR TITLE
fix: update regex validation

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/add_table/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/add_table/forms.py
@@ -107,7 +107,7 @@ class UploadCSVForm(GOVUKDesignSystemForm):
     def clean_csv_file(self):
         cleaned_data = super().clean()
         csv_name = cleaned_data["csv_file"]._name.replace(".csv", "")
-        if bool(re.search(r"[^A-Za-z_-]", csv_name)):
+        if not bool(re.search(r"^[A-Za-z0-9_-]+$", csv_name)):
             raise ValidationError(
                 "File name cannot contain special characters apart from underscores and hyphens"
             )


### PR DESCRIPTION
### Description of change
This change updates the regex validation in order to allow numbers in the CSV file name when using the "upload a csv" form.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?