### PR TITLE
Feat/add table view event to data usage

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1059,7 +1059,7 @@ class DatasetUsageHistoryView(View):
             )
         else:
             table_views = []
-        # collect SQL qury information from PostGres logs
+        # collect SQL query information from PostGres logs
         if dataset.type == DataSetType.MASTER:
             tables = list(dataset.sourcetable_set.values_list("table", flat=True))
             all_other_events = (

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1026,8 +1026,8 @@ class DataCutPreviewView(DetailView):
 class DatasetUsageHistoryView(View):
     def get(self, request, dataset_uuid, **kwargs):
         dataset = find_dataset(dataset_uuid, request.user, kwargs["model_class"])
-        # collect table views from attached source tabled
         if dataset.type in [DataSetType.DATACUT, DataSetType.MASTER]:
+            # collect table views from attached source tables
             if dataset.type == DataSetType.DATACUT:
                 tables = dataset.customdatasetquery_set
             else:
@@ -1059,8 +1059,8 @@ class DatasetUsageHistoryView(View):
             )
         else:
             table_views = []
-        # collect SQL query information from PostGres logs
         if dataset.type == DataSetType.MASTER:
+            # collect SQL query information from PostGres logs
             tables = list(dataset.sourcetable_set.values_list("table", flat=True))
             all_other_events = (
                 ToolQueryAuditLogTable.objects.filter(table__in=tables)
@@ -1072,6 +1072,7 @@ class DatasetUsageHistoryView(View):
                 .annotate(count=Count("id"))
             )
         else:
+            # DataCuts, Visualisation dataset events
             download_view_types = [
                 EventLog.TYPE_DATASET_SOURCE_LINK_DOWNLOAD,
                 EventLog.TYPE_DATASET_CUSTOM_QUERY_DOWNLOAD,
@@ -1107,7 +1108,7 @@ class DatasetUsageHistoryView(View):
                 .values("day", "email", "object", "event")
                 .annotate(count=Count("id"))
             )
-        # convert to standard python objects to combine two different model types
+        # convert Django QuerySet to standard python objects to combine two different model types
         all_events = sorted(
             list(all_other_events) + list(table_views), key=lambda x: x["day"], reverse=True
         )

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1107,6 +1107,7 @@ class DatasetUsageHistoryView(View):
                 .values("day", "email", "object", "event")
                 .annotate(count=Count("id"))
             )
+        # conver to standard python objects to combine two different model types
         all_events = sorted(
             list(all_other_events) + list(table_views), key=lambda x: x["day"], reverse=True
         )

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -17,16 +17,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import serializers
 from django.core.paginator import Paginator
 from django.db import ProgrammingError
-from django.db.models import (
-    Count,
-    F,
-    CharField,
-    Value,
-    Func,
-    Q,
-    Prefetch,
-    TextField,
-)
+from django.db.models import CharField, Count, F, Func, Prefetch, Q, TextField, Value
 from django.db.models.functions import Cast, TruncDay
 from django.forms.models import model_to_dict
 from django.http import (
@@ -42,11 +33,7 @@ from django.http import (
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.views.decorators.http import (
-    require_GET,
-    require_POST,
-    require_http_methods,
-)
+from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from django.views.generic import DetailView, FormView, TemplateView, UpdateView, View
 from psycopg2 import sql
 
@@ -55,8 +42,8 @@ from dataworkspace.apps.accounts.models import UserDataTableView
 from dataworkspace.apps.api_v1.core.views import invalidate_superset_user_cached_credentials
 from dataworkspace.apps.applications.models import ApplicationInstance
 from dataworkspace.apps.core.boto3_client import get_s3_client
-
 from dataworkspace.apps.core.errors import DatasetPermissionDenied, DatasetPreviewDisabledError
+from dataworkspace.apps.core.models import Database
 from dataworkspace.apps.core.utils import (
     StreamingHttpResponseWithoutDjangoDbConnection,
     database_dsn,
@@ -64,20 +51,13 @@ from dataworkspace.apps.core.utils import (
     table_data,
     view_exists,
 )
-from dataworkspace.apps.core.models import (
-    Database,
-)
-from dataworkspace.apps.datasets.constants import (
-    DataSetType,
-    DataLinkType,
-)
-from dataworkspace.apps.datasets.constants import TagType
+from dataworkspace.apps.datasets.constants import DataLinkType, DataSetType, TagType
 from dataworkspace.apps.datasets.forms import (
     DatasetEditForm,
     DatasetSearchForm,
     EligibilityCriteriaForm,
-    RelatedMastersSortForm,
     RelatedDataCutsSortForm,
+    RelatedMastersSortForm,
     RelatedVisualisationsSortForm,
     UserSearchForm,
     VisualisationCatalogueItemEditForm,
@@ -87,15 +67,15 @@ from dataworkspace.apps.datasets.models import (
     DataCutDataset,
     DataSet,
     DataSetUserPermission,
-    PendingAuthorizedUsers,
     MasterDataset,
+    PendingAuthorizedUsers,
     ReferenceDataset,
     SourceLink,
-    SourceView,
-    VisualisationCatalogueItem,
     SourceTable,
-    ToolQueryAuditLogTable,
+    SourceView,
     Tag,
+    ToolQueryAuditLogTable,
+    VisualisationCatalogueItem,
     VisualisationUserPermission,
 )
 from dataworkspace.apps.datasets.permissions.utils import (
@@ -108,11 +88,11 @@ from dataworkspace.apps.datasets.utils import (
     clean_dataset_restrictions_on_usage,
     dataset_type_to_manage_unpublished_permission_codename,
     find_dataset,
-    get_code_snippets_for_table,
     get_code_snippets_for_query,
     get_code_snippets_for_reference_table,
-    get_tools_links_for_user,
+    get_code_snippets_for_table,
     get_recently_viewed_catalogue_pages,
+    get_tools_links_for_user,
 )
 from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.apps.eventlog.utils import log_event, log_permission_change
@@ -762,7 +742,6 @@ class SourceLinkDownloadView(DetailView):
         source_link = get_object_or_404(
             SourceLink, id=self.kwargs.get("source_link_id"), dataset=dataset
         )
-
         log_event(
             request.user,
             EventLog.TYPE_DATASET_SOURCE_LINK_DOWNLOAD,
@@ -1047,20 +1026,30 @@ class DataCutPreviewView(DetailView):
 class DatasetUsageHistoryView(View):
     def get(self, request, dataset_uuid, **kwargs):
         dataset = find_dataset(dataset_uuid, request.user, kwargs["model_class"])
-        source_table_ids = dataset.sourcetable_set.annotate(
-                str_id=Cast("id", output_field=TextField())
-            ).values_list("str_id", flat=True)
-        table_view_events = EventLog.objects.filter(
-                object_id__in=source_table_ids, event_type=EventLog.TYPE_DATA_TABLE_VIEW
+        # collect table views from attached source tabled
+        if dataset.type in [DataSetType.DATACUT, DataSetType.MASTER]:
+            if dataset.type == DataSetType.DATACUT:
+                tables = dataset.customdatasetquery_set
+            else:
+                tables = dataset.sourcetable_set
+            table_ids = tables.annotate(str_id=Cast("id", output_field=TextField())).values_list(
+                "str_id", flat=True
             )
-        table_views = (
+            table_view_events = EventLog.objects.filter(
+                object_id__in=table_ids, event_type=EventLog.TYPE_DATA_TABLE_VIEW
+            )
+            table_views = (
                 table_view_events.annotate(event=Value("Viewed"))
                 .annotate(day=TruncDay("timestamp"))
                 .annotate(email=F("user__email"))
                 .annotate(
                     object=Func(
                         F("extra"),
-                        Value("data_table_tablename"),
+                        Value(
+                            "data_table_name"
+                            if dataset.type == DataSetType.DATACUT
+                            else "data_table_tablename"
+                        ),
                         function="jsonb_extract_path_text",
                         output_field=CharField(),
                     ),
@@ -1068,9 +1057,12 @@ class DatasetUsageHistoryView(View):
                 .values("day", "email", "object", "event")
                 .annotate(count=Count("id"))
             )
+        else:
+            table_views = []
+        # collect SQL qury information from PostGres logs
         if dataset.type == DataSetType.MASTER:
             tables = list(dataset.sourcetable_set.values_list("table", flat=True))
-            queries = (
+            all_other_events = (
                 ToolQueryAuditLogTable.objects.filter(table__in=tables)
                 .annotate(event=Value("Queried"))
                 .annotate(day=TruncDay("audit_log__timestamp"))
@@ -1079,34 +1071,27 @@ class DatasetUsageHistoryView(View):
                 .values("day", "email", "object", "event")
                 .annotate(count=Count("id"))
             )
-            all_events = sorted(
-                list(queries) + list(table_views), key=lambda x: x["day"], reverse=True
-            )
-            return render(
-                request,
-                "datasets/dataset_usage_history.html",
-                context={
-                    "dataset": dataset,
-                    "rows": all_events[:100],
-                },
-            )
-        download_view_types = [EventLog.TYPE_DATASET_SOURCE_LINK_DOWNLOAD,
-                        EventLog.TYPE_DATASET_CUSTOM_QUERY_DOWNLOAD]
-        return render(
-            request,
-            "datasets/dataset_usage_history.html",
-            context={
-                "dataset": dataset,
-                "rows": (table_views & dataset.events.filter(
-                    event_type__in=[
-                        EventLog.TYPE_DATASET_SOURCE_LINK_DOWNLOAD,
-                        EventLog.TYPE_DATASET_CUSTOM_QUERY_DOWNLOAD,
+        else:
+            download_view_types = [
+                EventLog.TYPE_DATASET_SOURCE_LINK_DOWNLOAD,
+                EventLog.TYPE_DATASET_CUSTOM_QUERY_DOWNLOAD,
+            ]
+            all_other_events = (
+                dataset.events.filter(
+                    event_type__in=download_view_types
+                    + [
                         EventLog.TYPE_VIEW_VISUALISATION_TEMPLATE,
                         EventLog.TYPE_VIEW_SUPERSET_VISUALISATION,
                         EventLog.TYPE_VIEW_QUICKSIGHT_VISUALISATION,
                     ]
                 )
-                .annotate(event=Value("Downloaded" if dataset.events.filter(event_type__in=download_view_types).count() > 0 else "Viewed"))
+                .annotate(
+                    event=Value(
+                        "Downloaded"
+                        if dataset.events.filter(event_type__in=download_view_types).count() > 0
+                        else "Viewed"
+                    )
+                )
                 .annotate(day=TruncDay("timestamp"))
                 .annotate(email=F("user__email"))
                 .annotate(
@@ -1120,7 +1105,17 @@ class DatasetUsageHistoryView(View):
                 )
                 .order_by("-day")
                 .values("day", "email", "object", "event")
-                .annotate(count=Count("id")))[:100],
+                .annotate(count=Count("id"))
+            )
+        all_events = sorted(
+            list(all_other_events) + list(table_views), key=lambda x: x["day"], reverse=True
+        )
+        return render(
+            request,
+            "datasets/dataset_usage_history.html",
+            context={
+                "dataset": dataset,
+                "rows": all_events[:100],
             },
         )
 

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1107,7 +1107,7 @@ class DatasetUsageHistoryView(View):
                 .values("day", "email", "object", "event")
                 .annotate(count=Count("id"))
             )
-        # conver to standard python objects to combine two different model types
+        # convert to standard python objects to combine two different model types
         all_events = sorted(
             list(all_other_events) + list(table_views), key=lambda x: x["day"], reverse=True
         )

--- a/dataworkspace/dataworkspace/templates/datasets/dataset_usage_history.html
+++ b/dataworkspace/dataworkspace/templates/datasets/dataset_usage_history.html
@@ -31,7 +31,7 @@
                         <tr class="govuk-table__row">
                             <td>{{ row.day|date:"d M Y" }}</td>
                             <td>{{ row.email }}</td>
-                            <td>{{ event_description }} {{ row.object }}</td>
+                            <td>{{ row.event }} {{ row.object }}</td>
                             <td>{{ row.count }}</td>
                         </tr>
                     {% empty %}

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -3138,6 +3138,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "test_table",
             "count": 1,
+            "event": "Queried",
         } in response.context["rows"]
 
     @pytest.mark.parametrize(
@@ -3175,6 +3176,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "test_table",
             "count": 1,
+            "event": "Queried",
         } in response.context["rows"]
 
         assert {
@@ -3182,6 +3184,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "test_table_2",
             "count": 2,
+            "event": "Queried",
         } in response.context["rows"]
 
     @pytest.mark.parametrize(
@@ -3226,6 +3229,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "test_table",
             "count": 1,
+            "event": "Queried",
         } in response.context["rows"]
 
         assert {
@@ -3233,6 +3237,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "test_table_2",
             "count": 3,
+            "event": "Queried",
         } in response.context["rows"]
 
         assert {
@@ -3240,6 +3245,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user-2@example.com",
             "object": "test_table_2",
             "count": 1,
+            "event": "Queried",
         } in response.context["rows"]
 
     @pytest.mark.parametrize(
@@ -3303,6 +3309,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "test_table",
             "count": 1,
+            "event": "Queried",
         } in response.context["rows"]
 
         assert {
@@ -3310,6 +3317,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "test_table_2",
             "count": 3,
+            "event": "Queried",
         } in response.context["rows"]
 
         assert {
@@ -3317,6 +3325,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user-2@example.com",
             "object": "test_table_2",
             "count": 1,
+            "event": "Queried",
         } in response.context["rows"]
 
         assert {
@@ -3324,6 +3333,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "test_table",
             "count": 1,
+            "event": "Queried",
         } in response.context["rows"]
 
         assert {
@@ -3331,6 +3341,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user-2@example.com",
             "object": "test_table",
             "count": 4,
+            "event": "Queried",
         } in response.context["rows"]
 
         assert {
@@ -3338,6 +3349,7 @@ class TestMasterDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "test_table_2",
             "count": 1,
+            "event": "Queried",
         } in response.context["rows"]
 
 

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -2801,18 +2801,19 @@ class TestDatasetUsageHistory:
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(
-        "url_name, fixture_name, event_factory",
+        "url_name, fixture_name, event_factory, event_type",
         (
-            ("usage_history", "dataset", factories.DatasetLinkDownloadEventFactory),
+            ("usage_history", "dataset", factories.DatasetLinkDownloadEventFactory, "Downloaded",),
             (
                 "visualisation_usage_history",
                 "visualisation",
                 factories.VisualisationViewedEventFactory,
+                "Viewed",
             ),
         ),
     )
     def test_one_event_by_one_user_on_the_same_day(
-        self, url_name, fixture_name, event_factory, staff_client, request
+        self, url_name, fixture_name, event_factory, event_type, staff_client, request
     ):
         catalogue_item = request.getfixturevalue(fixture_name)
         user = factories.UserFactory(email="test-user@example.com")
@@ -2832,23 +2833,27 @@ class TestDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "Test Event",
             "count": 1,
+            "event": event_type
         } in response.context["rows"]
+        
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(
-        "url_name, fixture_name, event_factory1, event_factory2",
+        "url_name, fixture_name, event_factory1, event_factory2, event_type",
         (
             (
                 "usage_history",
                 "dataset",
                 factories.DatasetLinkDownloadEventFactory,
                 factories.DatasetQueryDownloadEventFactory,
+                "Downloaded",
             ),
             (
                 "visualisation_usage_history",
                 "visualisation",
                 factories.VisualisationViewedEventFactory,
                 factories.SupersetVisualisationViewedEventFactory,
+                "Viewed",
             ),
         ),
     )
@@ -2858,6 +2863,7 @@ class TestDatasetUsageHistory:
         fixture_name,
         event_factory1,
         event_factory2,
+        event_type,
         staff_client,
         request,
     ):
@@ -2880,12 +2886,12 @@ class TestDatasetUsageHistory:
         response = staff_client.get(url)
         assert response.status_code == 200
         assert len(response.context["rows"]) == 2
-
         assert {
             "day": datetime(2021, 1, 1, tzinfo=timezone.utc),
             "email": "test-user@example.com",
             "object": "Test Event 1",
             "count": 1,
+            "event": event_type,
         } in response.context["rows"]
 
         assert {
@@ -2893,23 +2899,26 @@ class TestDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "Test Event 2",
             "count": 2,
+            "event": event_type,
         } in response.context["rows"]
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(
-        "url_name, fixture_name, event_factory1, event_factory2",
+        "url_name, fixture_name, event_factory1, event_factory2, event_type",
         (
             (
                 "usage_history",
                 "dataset",
                 factories.DatasetLinkDownloadEventFactory,
                 factories.DatasetQueryDownloadEventFactory,
+                "Downloaded",
             ),
             (
                 "visualisation_usage_history",
                 "visualisation",
                 factories.VisualisationViewedEventFactory,
                 factories.SupersetVisualisationViewedEventFactory,
+                "Viewed",
             ),
         ),
     )
@@ -2919,6 +2928,7 @@ class TestDatasetUsageHistory:
         fixture_name,
         event_factory1,
         event_factory2,
+        event_type,
         staff_client,
         request,
     ):
@@ -2953,6 +2963,7 @@ class TestDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "Test Event 1",
             "count": 1,
+            "event": event_type,
         } in response.context["rows"]
 
         assert {
@@ -2960,6 +2971,7 @@ class TestDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "Test Event 2",
             "count": 3,
+            "event": event_type,
         } in response.context["rows"]
 
         assert {
@@ -2967,23 +2979,26 @@ class TestDatasetUsageHistory:
             "email": "test-user-2@example.com",
             "object": "Test Event 2",
             "count": 1,
+            "event": event_type,
         } in response.context["rows"]
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(
-        "url_name, fixture_name, event_factory1, event_factory2",
+        "url_name, fixture_name, event_factory1, event_factory2, event_type",
         (
             (
                 "usage_history",
                 "dataset",
                 factories.DatasetLinkDownloadEventFactory,
                 factories.DatasetQueryDownloadEventFactory,
+                "Downloaded",
             ),
             (
                 "visualisation_usage_history",
                 "visualisation",
                 factories.VisualisationViewedEventFactory,
                 factories.SupersetVisualisationViewedEventFactory,
+                "Viewed",
             ),
         ),
     )
@@ -2993,6 +3008,7 @@ class TestDatasetUsageHistory:
         fixture_name,
         event_factory1,
         event_factory2,
+        event_type,
         staff_client,
         request,
     ):
@@ -3046,6 +3062,7 @@ class TestDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "Test Event 1",
             "count": 1,
+            "event": event_type,
         } in response.context["rows"]
 
         assert {
@@ -3053,6 +3070,7 @@ class TestDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "Test Event 2",
             "count": 3,
+            "event": event_type,
         } in response.context["rows"]
 
         assert {
@@ -3060,6 +3078,7 @@ class TestDatasetUsageHistory:
             "email": "test-user-2@example.com",
             "object": "Test Event 2",
             "count": 1,
+            "event": event_type,
         } in response.context["rows"]
 
         assert {
@@ -3067,6 +3086,7 @@ class TestDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "Test Event 1",
             "count": 1,
+            "event": event_type,
         } in response.context["rows"]
 
         assert {
@@ -3074,6 +3094,7 @@ class TestDatasetUsageHistory:
             "email": "test-user-2@example.com",
             "object": "Test Event 1",
             "count": 4,
+            "event": event_type,
         } in response.context["rows"]
 
         assert {
@@ -3081,6 +3102,7 @@ class TestDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "Test Event 2",
             "count": 1,
+            "event": event_type,
         } in response.context["rows"]
 
 

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -2803,7 +2803,12 @@ class TestDatasetUsageHistory:
     @pytest.mark.parametrize(
         "url_name, fixture_name, event_factory, event_type",
         (
-            ("usage_history", "dataset", factories.DatasetLinkDownloadEventFactory, "Downloaded",),
+            (
+                "usage_history",
+                "dataset",
+                factories.DatasetLinkDownloadEventFactory,
+                "Downloaded",
+            ),
             (
                 "visualisation_usage_history",
                 "visualisation",
@@ -2833,9 +2838,8 @@ class TestDatasetUsageHistory:
             "email": "test-user@example.com",
             "object": "Test Event",
             "count": 1,
-            "event": event_type
+            "event": event_type,
         } in response.context["rows"]
-        
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of change

Views stats for source tables as part of datasets were missing. A bit of chopping and changing had to be done to get this to work with download and query stats as part of one rendered table.

See https://uktrade.atlassian.net/browse/DT-2047?atlOrigin=eyJpIjoiYjNiNjA2MDJjYjUwNDM2OGJmM2M5ODE3OGI1OWQwMmIiLCJwIjoiaiJ9

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?