### PR TITLE
trying to bump the R version from cran

### DIFF
--- a/visualisation-base-rv4/Dockerfile
+++ b/visualisation-base-rv4/Dockerfile
@@ -7,7 +7,7 @@ RUN \
         ca-certificates \
 		dirmngr \
 		gnupg2 && \
-    echo "en_GB.UTF-8 UTF-8" >> /etc/locale.gen && \
+	echo "en_GB.UTF-8 UTF-8" >> /etc/locale.gen && \
 	locale-gen en_GB.utf8 && \
 	rm -rf /var/lib/apt/lists/*
 
@@ -23,15 +23,14 @@ RUN \
 		dirmngr \
 		gnupg2 && \
 	rm -rf /var/lib/apt/lists/* && \
-    echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ bullseye main" > /etc/apt/sources.list && \
-	echo "Acquire{Check-Valid-Until false; Retries 10;}" >> /etc/apt/apt.conf && \
+    echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian bullseye-cran40/" >> /etc/apt/sources.list && \
 	until apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'; do sleep 10; done && \
-    gpg --armor --export '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' | tee /etc/apt/trusted.gpg.d/cran_debian_key.asc && \
     rm -rf /var/lib/apt/lists/* && \
 	apt-get update && \
     apt-get install -y \
-        r-base \
-        r-recommended && \
+		r-base-dev=4.4.0-2~bullseyecran.0 \
+		r-base=4.0.4-2~bullseyecran.0 \
+		r-recommended=4.0.4-2~bullseyecran.0 && \
 	rm -rf /var/lib/apt/lists/* && \
 	# Remove the last line from sources: the CRAN debian repo that has R itself, which we don't mirror
 	sed -i '$d' /etc/apt/sources.list && \


### PR DESCRIPTION
WiP to checkout, keep getting the version doesn't exist even though it does in https://cran.ma.imperial.ac.uk/bin/linux/debian/bullseye-cran40/