### PR TITLE
fix/DT-2371:  Add template filter to correctly format the table name

### DIFF
--- a/cypress/e2e/data-catalogue/data-grid.cy.ts
+++ b/cypress/e2e/data-catalogue/data-grid.cy.ts
@@ -37,7 +37,7 @@ describe("Data grid filters", () => {
           ],
         },
       }).as("getData");
-      cy.get("a").contains("source_data_set").click();
+      cy.get("a").contains("Source data set").click();
       checkRequestBody("@getData", '"filters":{}');
       cy.get("span.ag-icon.ag-icon-menu").last().click();
 

--- a/cypress/e2e/data-catalogue/source-dataset.cy.ts
+++ b/cypress/e2e/data-catalogue/source-dataset.cy.ts
@@ -1,7 +1,6 @@
 import {
   sourceWithTable,
   sourceWithTableNoPermissions,
-  datacutWithNoPermissions,
 } from "../../fixtures/datasets";
 import {
   assertTextAndLinks,
@@ -64,7 +63,7 @@ describe("Source dataset catalogue", () => {
         rows: [
           [
             {
-              text: "source_data_set",
+              text: "Source data set",
             },
             {
               text: "public.test_dataset",
@@ -189,7 +188,7 @@ describe("Source dataset catalogue", () => {
         rows: [
           [
             {
-              text: "source_data_set",
+              text: "Source data set",
             },
             {
               text: "public.test_dataset",

--- a/dataworkspace/dataworkspace/apps/datasets/templatetags/datasets_tags.py
+++ b/dataworkspace/dataworkspace/apps/datasets/templatetags/datasets_tags.py
@@ -182,3 +182,8 @@ def saved_grid_config(user, source):
 @register.filter
 def timedelta_to_minutes(td):
     return round(td.total_seconds() / 60, 2)
+
+
+@register.filter
+def format_table_name(table_name):
+    return table_name.capitalize().replace("_", " ")

--- a/dataworkspace/dataworkspace/templates/datasets/details/sourceset_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/details/sourceset_dataset.html
@@ -117,11 +117,11 @@
                 {% if has_access %}
                   {% if source_table.data_grid_enabled %}
                   <a class="govuk-link" href="{% url "datasets:source_table_detail" dataset_uuid=dataset.id object_id=source_table.id %}">
-                    {{ source_table.name }}
+                    {{ source_table.name|format_table_name }}
                   </a>
                 {% endif %}
                 {% else %}
-                  {{ source_table.name }}
+                  {{ source_table.name|format_table_name }}
                 {% endif %}
               {% endif %}
             </td>

--- a/dataworkspace/dataworkspace/tests/datasets/test_datasets_tags.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_datasets_tags.py
@@ -1,0 +1,15 @@
+from dataworkspace.apps.datasets.templatetags.datasets_tags import format_table_name
+
+
+class TestFormatTableName:
+    def test_should_correctly_format_table_name(self):
+        test_cases = [
+            "This_Is_A_Table_Name",
+            "this_is_a_table_name",
+            "THIS_IS_A_TABLE_NAME",
+            "tHIS_iS_a_tABLE_nAME",
+            "This_is_a_table_name",
+        ]
+
+        for test in test_cases:
+            assert format_table_name(test) == "This is a table name"


### PR DESCRIPTION
### Description of change
Ticket: [DT-2371](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-2371)

Currently all the new tables being created via the new "add table" journey are being formatted with underscores between each word. This change adds a template filter that will format the table correctly. It replaces the underscore with a space and sentence cases the name. 

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?

[DT-2371]: https://uktrade.atlassian.net/browse/DT-2371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ