### PR TITLE
Fix/codeql sql query built from user submitted code

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=
+extension-pkg-whitelist=pglast
 
 # Specify a score threshold to be exceeded before program exits with error.
 fail-under=10

--- a/dataworkspace/dataworkspace/apps/explorer/tasks.py
+++ b/dataworkspace/dataworkspace/apps/explorer/tasks.py
@@ -68,8 +68,6 @@ def cleanup_temporary_query_tables():
         server_db_user = DATABASES_DATA[query_log.connection]["USER"]
         db_role = f"{USER_SCHEMA_STEM}{db_role_schema_suffix_for_user(query_log.run_by_user)}"
         table_schema_and_name = tempory_query_table_name(query_log.run_by_user, query_log.id)
-        print("db_role")
-        print("server_db_user", server_db_user)
         with cache.lock(
             f'database-grant--{DATABASES_DATA[query_log.connection]["NAME"]}--{db_role}--v4',
             blocking_timeout=3,

--- a/dataworkspace/dataworkspace/apps/explorer/tasks.py
+++ b/dataworkspace/dataworkspace/apps/explorer/tasks.py
@@ -8,7 +8,6 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.db import connections, IntegrityError, transaction
 
-import psycopg2.sql
 from pytz import utc
 
 from dataworkspace.apps.core.utils import (
@@ -196,14 +195,11 @@ def _run_query(conn, query_log, page, limit, timeout, output_table):
             for i, col in enumerate(cursor.description, 1)
         ]
         cols_formatted = ", ".join(prefixed_sql_columns)
-        print("cols_formatted", cols_formatted)
         output_table_schema, output_table_name = output_table.split(".")
-        query = psycopg2.sql.SQL("CREATE TABLE {output_table} ({cols_formatted})").format(
+        cursor.execute(psycopg2.sql.SQL("CREATE TABLE {output_table} ({cols_formatted})").format(
             output_table=psycopg2.sql.Identifier(output_table_schema, output_table_name),
             cols_formatted=psycopg2.sql.SQL(cols_formatted),
-        )
-        print("myquery", query.as_string(conn))
-        cursor.execute(query)
+        ))
         limit_clause = ""
         if limit is not None:
             limit_clause = f"LIMIT {limit}"

--- a/dataworkspace/dataworkspace/apps/explorer/tasks.py
+++ b/dataworkspace/dataworkspace/apps/explorer/tasks.py
@@ -196,10 +196,12 @@ def _run_query(conn, query_log, page, limit, timeout, output_table):
         ]
         cols_formatted = ", ".join(prefixed_sql_columns)
         output_table_schema, output_table_name = output_table.split(".")
-        cursor.execute(psycopg2.sql.SQL("CREATE TABLE {output_table} ({cols_formatted})").format(
-            output_table=psycopg2.sql.Identifier(output_table_schema, output_table_name),
-            cols_formatted=psycopg2.sql.SQL(cols_formatted),
-        ))
+        cursor.execute(
+            psycopg2.sql.SQL("CREATE TABLE {output_table} ({cols_formatted})").format(
+                output_table=psycopg2.sql.Identifier(output_table_schema, output_table_name),
+                cols_formatted=psycopg2.sql.SQL(cols_formatted),
+            )
+        )
         limit_clause = ""
         if limit is not None:
             limit_clause = f"LIMIT {limit}"

--- a/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
@@ -94,7 +94,7 @@ class TestTasks(TestCase):
                 )
             ),
             call(
-                SQL("REVOKE {user} FROM {role}}").format(
+                SQL("REVOKE {user} FROM {role}").format(
                     user=Identifier("_user_12b9377c"),
                     role=Identifier("postgres"),
                 ),
@@ -150,11 +150,11 @@ class TestExecuteQuery:
                 ),
             ),
             call(
-                SQL("INSERT INTO {schema_table} SELECT * FROM {sql} sq {limit}").format(
+                SQL("INSERT INTO {schema_table} SELECT * FROM ({sql}) sq {limit}").format(
                     schema_table=Identifier(
                         "_user_12b9377c", f"_data_explorer_tmp_query_{query_log_id}"
                     ),
-                    sql=SQL("(select * from foo)"),
+                    sql=SQL("select * from foo"),
                     limit=SQL("LIMIT 100"),
                 ),
             ),
@@ -186,7 +186,9 @@ class TestExecuteQuery:
             ),
             call(
                 SQL("CREATE TABLE {schema_table}  {cols}").format(
-                    query=Identifier("_user_12b9377c", f"_data_explorer_tmp_query_{query_log_id}"),
+                    schema_table=Identifier(
+                        "_user_12b9377c", f"_data_explorer_tmp_query_{query_log_id}"
+                    ),
                     cols=SQL('("foo" integer, "bar" text)'),
                 )
             ),

--- a/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
@@ -139,12 +139,8 @@ class TestExecuteQuery:
         query_log_id = QueryLog.objects.first().id
 
         expected_calls = [
-            call("SET statement_timeout = %s", ("10000",)),
-            call(
-                SQL("SELECT * FROM ({query}) sq {limit}").format(
-                    query=SQL("select * from foo"), limit=SQL("LIMIT 0")
-                )
-            ),
+            call("SET statement_timeout = %s", (10000,)),
+            call(SQL("SELECT * FROM ({query}) sq LIMIT 0").format(query=SQL("select * from foo"))),
             call(
                 SQL("CREATE TABLE {schema_table} ({cols})").format(
                     schema_table=Identifier(
@@ -182,12 +178,8 @@ class TestExecuteQuery:
         query_log_id = QueryLog.objects.first().id
 
         expected_calls = [
-            call("SET statement_timeout = %s", ("10000",)),
-            call(
-                SQL("SELECT * FROM ({query}) sq {limit}").format(
-                    query=SQL("select * from foo"), limit=SQL("LIMIT 0")
-                )
-            ),
+            call("SET statement_timeout = %s", (10000,)),
+            call(SQL("SELECT * FROM ({query}) sq LIMIT 0").format(query=SQL("select * from foo"))),
             call(
                 SQL("CREATE TABLE {schema_table}  {cols}").format(
                     schema_table=Identifier(
@@ -229,23 +221,16 @@ class TestExecuteQuery:
         query_log_id = QueryLog.objects.first().id
 
         expected_calls = [
-            call("SET statement_timeout = %s", ("10000",)),
-            call(
-                SQL("SELECT * FROM {query} sq {limit}").format(
-                    query=SQL("select * from foo"), limit=SQL("LIMIT 0")
-                )
-            ),
+            call("SET statement_timeout = %s", (10000,)),
+            call(SQL("SELECT * FROM {query} sq LIMIT 0").format(query=SQL("select * from foo"))),
             call(
                 SQL("CREATE TABLE {table}{cols}").format(
                     table=Identifier("_user_12b9377c", f"_data_explorer_tmp_query_{query_log_id}"),
-                    cols=SQL('("col_1_bar" integer, "col_2_bar" text)'),
+                    cols=SQL('"col_1_bar" integer, "col_2_bar" text'),
                 )
             ),
             call(
-                SQL(
-                    """INSERT INTO {schema_table}
-                    SELECT * FROM ({sql}) sq {limit}"""
-                ).format(
+                SQL("INSERT INTO {schema_table} SELECT * FROM ({sql}) sq {limit}").format(
                     schema_table=Identifier(
                         "_user_12b9377c", f"_data_explorer_tmp_query_{query_log_id}"
                     ),

--- a/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
@@ -141,7 +141,7 @@ class TestExecuteQuery:
             call("SET statement_timeout = %s", (10000,)),
             call("SELECT * FROM (%s) sq LIMIT 0", ("select * from foo",)),
             call(
-                f"CREATE TABLE %s (%s)",
+                "CREATE TABLE %s (%s)",
                 (
                     f"_user_12b9377c._data_explorer_tmp_query_{query_log_id}",
                     '"foo" integer, "bar" text',

--- a/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
@@ -83,7 +83,8 @@ class TestTasks(TestCase):
         expected_calls = [
             call(
                 SQL("GRANT {user} TO {role}").format(
-                    user=Identifier("_user_12b9377c"), role=Identifier("postgres")
+                    role=Identifier("postgres"),
+                    user=Identifier("_user_12b9377c"),
                 ),
             ),
             call(
@@ -95,8 +96,8 @@ class TestTasks(TestCase):
             ),
             call(
                 SQL("REVOKE {user} FROM {role}").format(
-                    user=Identifier("_user_12b9377c"),
                     role=Identifier("postgres"),
+                    user=Identifier("_user_12b9377c"),
                 ),
             ),
         ]
@@ -150,12 +151,13 @@ class TestExecuteQuery:
                 ),
             ),
             call(
-                SQL("INSERT INTO {schema_table} SELECT * FROM ({sql}) sq {limit}").format(
+                SQL("INSERT INTO {schema_table} SELECT * FROM ({sql}) sq {limit}{offset}").format(
                     schema_table=Identifier(
                         "_user_12b9377c", f"_data_explorer_tmp_query_{query_log_id}"
                     ),
                     sql=SQL("select * from foo"),
                     limit=SQL("LIMIT 100"),
+                    offset=SQL(""),
                 ),
             ),
             call(SQL("SELECT COUNT(*) FROM ({sql}) sq").format(sql=SQL("select * from foo"))),
@@ -181,24 +183,23 @@ class TestExecuteQuery:
             call("SET statement_timeout = %s", (10000,)),
             call(SQL("SELECT * FROM ({query}) sq LIMIT 0").format(query=SQL("select * from foo"))),
             call(
-                SQL("CREATE TABLE {schema_table}  {cols}").format(
+                SQL("CREATE TABLE {schema_table} ({cols})").format(
                     schema_table=Identifier(
                         "_user_12b9377c", f"_data_explorer_tmp_query_{query_log_id}"
                     ),
-                    cols=SQL('("foo" integer, "bar" text)'),
+                    cols=SQL('"foo" integer, "bar" text'),
                 )
             ),
             call(
                 SQL(
-                    """INSERT INTO {schema_table}
-                SELECT * FROM ({query}) sq {limit} {offset}"""
+                    "INSERT INTO {schema_table} SELECT * FROM ({query}) sq {limit}{offset}"
                 ).format(
                     schema_table=Identifier(
                         "_user_12b9377c", f"_data_explorer_tmp_query_{query_log_id}"
                     ),
                     query=SQL("select * from foo"),
                     limit=SQL("LIMIT 100"),
-                    offset=SQL("OFFSET 100"),
+                    offset=SQL(" OFFSET 100"),
                 )
             ),
             call(SQL("SELECT COUNT(*) FROM ({query}) sq").format(query=SQL("select * from foo"))),
@@ -222,20 +223,21 @@ class TestExecuteQuery:
 
         expected_calls = [
             call("SET statement_timeout = %s", (10000,)),
-            call(SQL("SELECT * FROM {query} sq LIMIT 0").format(query=SQL("select * from foo"))),
+            call(SQL("SELECT * FROM ({query}) sq LIMIT 0").format(query=SQL("select * from foo"))),
             call(
-                SQL("CREATE TABLE {table}{cols}").format(
+                SQL("CREATE TABLE {table} ({cols})").format(
                     table=Identifier("_user_12b9377c", f"_data_explorer_tmp_query_{query_log_id}"),
                     cols=SQL('"col_1_bar" integer, "col_2_bar" text'),
                 )
             ),
             call(
-                SQL("INSERT INTO {schema_table} SELECT * FROM ({sql}) sq {limit}").format(
+                SQL("INSERT INTO {schema_table} SELECT * FROM ({sql}) sq {limit}{offset}").format(
                     schema_table=Identifier(
                         "_user_12b9377c", f"_data_explorer_tmp_query_{query_log_id}"
                     ),
                     sql=SQL("select * from foo"),
                     limit=SQL("LIMIT 100"),
+                    offset=SQL(""),
                 )
             ),
             call(SQL("SELECT COUNT(*) FROM ({sql}) sq").format(sql=SQL("select * from foo"))),

--- a/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
@@ -5,6 +5,7 @@ from mock import call, Mock, MagicMock, patch
 from django.core.serializers.json import DjangoJSONEncoder
 from django.test import TestCase
 from freezegun import freeze_time
+from psycopg2.sql import Identifier, SQL
 import pytest
 import six
 
@@ -28,7 +29,6 @@ from dataworkspace.tests.explorer.factories import (
     SimpleQueryFactory,
 )
 from dataworkspace.tests.factories import UserFactory
-from psycopg2.sql import Identifier, SQL
 
 
 class TestTasks(TestCase):


### PR DESCRIPTION
### Description of change
See https://github.com/uktrade/data-workspace-frontend/security/code-scanning/10, use psycopg2 inbuilt SQL parsing methods to control user input.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?