### PR TITLE
Refactor/DT-2389: E2E tests for data access review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,14 @@ docker-a11y = docker compose -f docker-compose.yml -f docker-compose.a11y.yml -p
 e2e-export-models = auth.User core.Database \
 	accounts.Profile datasets.SensitivityType \
 	datasets.Dataset datasets.SourceLink \
+	datasets.MasterDataset \
 	datasets.SourceTable \
-	datasets.DatasetUserPermission \
+	datasets.DataSetuserPermission \
 	datasets.SourceTableFieldDefinition \
 	datasets.SourceView \
 	datasets.DatasetBookmark \
 	datasets.CustomDatasetQuery \
-	data_collections.Collection
+	data_collections.Collection \
 
 .PHONY: help test
 help:
@@ -70,6 +71,15 @@ docker-e2e-build-run:
 .PHONY: docker-e2e-start
 docker-e2e-start:
 	$(docker-e2e) up --build --renew-anon-volumes --force-recreate -d
+
+.PHONY: docker-e2e-up
+docker-e2e-up:
+	$(docker-e2e) up -d
+
+.PHONY: docker-e2e-down
+docker-e2e-down:
+	$(docker-e2e) down
+
 
 .PHONY: docker-a11y-build
 docker-a11y-build:

--- a/cypress/e2e/access-requests/data-access-request.cy.ts
+++ b/cypress/e2e/access-requests/data-access-request.cy.ts
@@ -155,7 +155,7 @@ describe("Removing access", () => {
     });
     it("should remove the users access to the dataset", () => {
       cy.findByRole("button", {
-        name: "Remove User",
+        name: "Remove user",
       }).click();
       cy.findByRole("dialog").within(() => {
         cy.findByRole("heading", {

--- a/cypress/e2e/access-requests/data-access-request.cy.ts
+++ b/cypress/e2e/access-requests/data-access-request.cy.ts
@@ -163,7 +163,7 @@ describe("Removing access", () => {
           level: 2,
         }).should("be.visible");
         cy.findByRole("button", {
-          name: "Yes, Remove user",
+          name: "Yes, remove user",
         }).click();
       });
       assertSuccessNotification(

--- a/cypress/e2e/access-requests/data-access-request.cy.ts
+++ b/cypress/e2e/access-requests/data-access-request.cy.ts
@@ -163,7 +163,7 @@ describe("Removing access", () => {
           level: 2,
         }).should("be.visible");
         cy.findByRole("button", {
-          name: "Yes, Remove User",
+          name: "Yes, Remove user",
         }).click();
       });
       assertSuccessNotification(

--- a/cypress/e2e/access-requests/data-access-request.cy.ts
+++ b/cypress/e2e/access-requests/data-access-request.cy.ts
@@ -1,0 +1,186 @@
+import { sourceWithTableNoAccess } from "../../fixtures/datasets";
+import {
+  assertDataAccessNotification,
+  assertSuccessNotification,
+} from "../../support/assertions";
+
+describe("Requesting data access", () => {
+  context("when I request access to this dataset", () => {
+    beforeEach(() => {
+      cy.setUsersEditorAccess(sourceWithTableNoAccess, false);
+      cy.visit(`/datasets/${sourceWithTableNoAccess}`);
+      cy.findByRole("link", { name: "Request access to data" }).click();
+    });
+    it("should display an error message when I don't enter a reason", () => {
+      cy.findByRole("heading", {
+        name: "Request access to data",
+        level: 1,
+      }).should("be.visible");
+      cy.get("form")
+        .findByRole("textbox", {
+          name: "Contact email",
+        })
+        .should("have.attr", "value", "vyvyan.holland@businessandtrade.gov.uk");
+
+      cy.get("form").findByRole("button").click();
+      cy.findByRole("alert").within(() => {
+        cy.findByRole("heading", {
+          name: "There is a problem",
+          level: 2,
+        }).should("be.visible");
+        cy.findByRole("link", {
+          name: "Enter a reason for requesting this data.",
+        }).should("be.visible");
+      });
+    });
+    it("should summarize your request when you correctly fill out the form", () => {
+      cy.get("form")
+        .findByRole("textbox", {
+          name: "Why do you need this data?",
+        })
+        .type("I need it");
+      cy.get("form").findByRole("button").click();
+      cy.findByRole("heading", {
+        name: "Check your answers before sending your request",
+        level: 1,
+      }).should("be.visible");
+      cy.findByText("Contact email")
+        .should("be.visible")
+        .next("dd")
+        .findByText("vyvyan.holland@businessandtrade.gov.uk")
+        .should("be.visible");
+
+      cy.findByText("Reason to access this data")
+        .should("be.visible")
+        .next("dd")
+        .findByText("I need it")
+        .should("be.visible");
+      cy.get("form").findByRole("button", { name: "Submit" }).click();
+
+      cy.findByRole("heading", {
+        name: "Request complete",
+        level: 1,
+      }).should("be.visible");
+
+      cy.findByText("You've requested access to")
+        .should("be.visible")
+        .findByRole("link", { name: "Source dataset - access request." })
+        .should("be.visible")
+        .should(
+          "have.attr",
+          "href",
+          `/datasets/${sourceWithTableNoAccess}#source-dataset-access-request`
+        );
+    });
+  });
+});
+
+describe("Approving and denying the data access request", () => {
+  context("when I review the access request and deny access", () => {
+    before(() => {
+      cy.setUsersEditorAccess(sourceWithTableNoAccess, true);
+      cy.visit(`/datasets/${sourceWithTableNoAccess}/review-access/2`);
+    });
+    it("should confirm that the request has been denied", () => {
+      cy.findByRole("radio", {
+        name: "Deny Vyvyan Holland access to this dataset",
+      }).click();
+      cy.findByRole("textbox", {
+        name: "Why are you denying access to this data?",
+      }).type("Sorry you are not allowed");
+      cy.get("form").findByRole("button", { name: "Submit" }).click();
+      assertSuccessNotification(
+        "An email has been sent to Vyvyan Holland to let them know their access request was not successful."
+      );
+    });
+
+    it("should only display the IAO user", () => {
+      cy.visit(`datasets/${sourceWithTableNoAccess}/edit-permissions`);
+      cy.findByRole("heading", {
+        name: "Manage access to Source dataset - access request",
+        level: 1,
+      }).should("be.visible");
+      cy.findByRole("heading", {
+        name: "Users who have access",
+        level: 2,
+      }).should("be.visible");
+      cy.get("table").within(() => {
+        cy.get("tr").should("have.length", 1);
+        cy.get("td").contains("Bob Testerson (Information Asset Manager)");
+      });
+    });
+  });
+  context("when I review the access request and approve access", () => {
+    before(() => {
+      cy.visit(`/datasets/${sourceWithTableNoAccess}/review-access/2`);
+    });
+    it("should confirm that the request has been approved", () => {
+      cy.findByRole("radio", {
+        name: "Grant Vyvyan Holland access to this dataset",
+      }).click();
+      cy.get("form").findByRole("button", { name: "Submit" }).click();
+      assertSuccessNotification(
+        "An email has been sent to Vyvyan Holland to let them know they now have access."
+      );
+    });
+    it("should NOT display a notification for requesting access to the dataset", () => {
+      cy.visit(`/datasets/${sourceWithTableNoAccess}`);
+      cy.findAllByTestId("request-access-to-data").should("not.exist");
+    });
+    it("should display two users who have access", () => {
+      cy.visit(`datasets/${sourceWithTableNoAccess}/edit-permissions`);
+      cy.findByRole("heading", {
+        name: "Manage access to Source dataset - access request",
+        level: 1,
+      }).should("be.visible");
+
+      cy.findByRole("heading", {
+        name: "Users who have access",
+        level: 2,
+      }).should("be.visible");
+      cy.get("table").within(() => {
+        cy.get("tr").should("have.length", 2);
+        cy.get("td").contains(
+          "Bob Testerson (Information Asset Manager) (Information Asset Owner)"
+        );
+        cy.get("td").contains("Vyvyan Holland");
+      });
+    });
+  });
+});
+
+describe("Removing access", () => {
+  context("when I remove the users data access", () => {
+    before(() => {
+      cy.setUsersEditorAccess(sourceWithTableNoAccess, true);
+      cy.visit(`datasets/${sourceWithTableNoAccess}/edit-permissions`);
+    });
+    it("should remove the users access to the dataset", () => {
+      cy.findByRole("button", {
+        name: "Remove User",
+      }).click();
+      cy.findByRole("dialog").within(() => {
+        cy.findByRole("heading", {
+          name: "Are you sure you want to remove Vyvyan Holland's access to this data?",
+          level: 2,
+        }).should("be.visible");
+        cy.findByRole("button", {
+          name: "Yes, Remove User",
+        }).click();
+      });
+      assertSuccessNotification(
+        "Vyvyan Holland's access to data has been removed. An email has been sent out to let them know that they no longer have access to the data."
+      );
+      cy.findByRole("link", {
+        name: "View catalogue page",
+      })
+        .should("be.visible")
+        .click();
+    });
+    it("should display a request access notification to the dataset", () => {
+      cy.setUsersEditorAccess(sourceWithTableNoAccess, false);
+      cy.visit(`datasets/${sourceWithTableNoAccess}`);
+      assertDataAccessNotification(sourceWithTableNoAccess);
+    });
+  });
+});

--- a/cypress/e2e/access-requests/data-access-request.cy.ts
+++ b/cypress/e2e/access-requests/data-access-request.cy.ts
@@ -140,9 +140,7 @@ describe("Approving and denying the data access request", () => {
       }).should("be.visible");
       cy.get("table").within(() => {
         cy.get("tr").should("have.length", 2);
-        cy.get("td").contains(
-          "Bob Testerson (Information Asset Manager) (Information Asset Owner)"
-        );
+        cy.get("td").contains("Bob Testerson (Information Asset Manager)");
         cy.get("td").contains("Vyvyan Holland");
       });
     });

--- a/cypress/e2e/homepage/dashboard.cy.ts
+++ b/cypress/e2e/homepage/dashboard.cy.ts
@@ -15,30 +15,30 @@ describe("Homepage dashboard", () => {
       cy.findByRole("heading", {
         level: 2,
         name: "How we can support you",
-      }).should("exist");
+      }).should("be.visible");
     });
 
     it("should show a 'Get help' article", () => {
       cy.findByRole("heading", {
         level: 3,
         name: "Get help",
-      }).should("exist");
+      }).should("be.visible");
       cy.findByRole("heading", {
         level: 4,
         name: "Suggested articles",
-      }).should("exist");
+      }).should("be.visible");
     });
 
     it("should show a 'Get in touch' article", () => {
       cy.findByRole("heading", {
         level: 3,
         name: "Get in touch",
-      }).should("exist");
+      }).should("be.visible");
       ["Message", "Community", "Work"].forEach((message) => {
         cy.findByRole("heading", {
           level: 4,
           name: message,
-        }).should("exist");
+        }).should("be.visible");
       });
     });
   });
@@ -61,7 +61,7 @@ describe("Homepage dashboard", () => {
       cy.findByRole("heading", {
         level: 2,
         name: "Your recent items",
-      }).should("exist");
+      }).should("be.visible");
       cy.findByRole("link", { name: "Data cut - links" }).should("not.exist");
       cy.findByRole("link", { name: "Data types on Data Workspace" }).should(
         "exist"
@@ -74,11 +74,13 @@ describe("Homepage dashboard", () => {
       cy.findByRole("heading", {
         level: 2,
         name: "Your recent collections",
-      }).should("exist");
-      cy.findByRole("link", { name: "Create a collection" }).should("exist");
+      }).should("be.visible");
+      cy.findByRole("link", { name: "Create a collection" }).should(
+        "be.visible"
+      );
       cy.findByRole("link", {
         name: "Find out more about collections",
-      }).should("exist");
+      }).should("be.visible");
       cy.findByRole("link", {
         name: "Personal collection a",
       }).should("not.exist");
@@ -89,8 +91,8 @@ describe("Homepage dashboard", () => {
       cy.findByRole("heading", {
         level: 2,
         name: "Your recent tools",
-      }).should("exist");
-      cy.findByRole("link", { name: "Visit tools" }).should("exist");
+      }).should("be.visible");
+      cy.findByRole("link", { name: "Visit tools" }).should("be.visible");
       cy.findByRole("link", { name: "Find out more about tools" }).should(
         "exist"
       );
@@ -102,7 +104,7 @@ describe("Homepage dashboard", () => {
       cy.findByRole("heading", {
         level: 2,
         name: "Your bookmarks",
-      }).should("exist");
+      }).should("be.visible");
       cy.findByRole("link", { name: "Data cut - links" }).should("not.exist");
       cy.findByRole("link", { name: "View all bookmarks" }).should("not.exist");
     });
@@ -110,10 +112,62 @@ describe("Homepage dashboard", () => {
 
   context("When an exisiting user visits the page", () => {
     beforeEach(() => {
-      cy.intercept(endpoints.recentItems).as("recentItems");
-      cy.intercept(endpoints.recentCollections).as("recentCollections");
-      cy.intercept(endpoints.recentTools).as("recentTools");
-      cy.intercept(endpoints.yourBookmarks).as("yourBookmarks");
+      cy.intercept(endpoints.recentItems, {
+        results: [
+          {
+            id: 1,
+            timestamp: "2024-11-14T13:20:56.068509Z",
+            event_type: "Dataset view",
+            user_id: 2,
+            related_object: {
+              id: "1234",
+              type: "Source dataset",
+              name: "Some source dataset",
+            },
+            extra: {
+              path: "/datasets/1234",
+            },
+          },
+        ],
+      }).as("recentItems");
+      cy.intercept(endpoints.recentCollections, {
+        results: [
+          {
+            name: "Ian's source data set",
+            datasets: [],
+            visualisation_catalogue_items: [],
+            collection_url: "/collections/1234",
+          },
+        ],
+      }).as("recentCollections");
+      cy.intercept(endpoints.recentTools, {
+        results: [
+          {
+            id: 1,
+            extra: {
+              tool: "Data Explorer",
+            },
+            tool_url: "/tools/explorer/redirect",
+          },
+          {
+            id: 2,
+            extra: {
+              tool: "Superset",
+            },
+            tool_url: "/tools/superset/redirect",
+          },
+        ],
+      }).as("recentTools");
+      cy.intercept(endpoints.yourBookmarks, {
+        results: [
+          {
+            id: "1234",
+            name: "Some bookmarked dataset",
+            url: "/datasets/1234",
+            created: "2023-12-18T15:22:42.860061Z",
+          },
+        ],
+      }).as("yourBookmarks");
       cy.visit("/");
     });
 
@@ -122,8 +176,10 @@ describe("Homepage dashboard", () => {
       cy.findByRole("heading", {
         level: 2,
         name: "Your recent items",
-      }).should("exist");
-      cy.findByRole("link", { name: "Data cut - links" }).should("exist");
+      }).should("be.visible");
+      cy.findByRole("link", { name: "Some source dataset" }).should(
+        "be.visible"
+      );
       cy.findByRole("link", { name: "Data types on Data Workspace" }).should(
         "not.exist"
       );
@@ -134,7 +190,7 @@ describe("Homepage dashboard", () => {
       cy.findByRole("heading", {
         level: 2,
         name: "Your recent collections",
-      }).should("exist");
+      }).should("be.visible");
       cy.findByRole("link", { name: "Create a collection" }).should(
         "not.exist"
       );
@@ -142,8 +198,8 @@ describe("Homepage dashboard", () => {
         name: "Find out more about collections",
       }).should("not.exist");
       cy.findAllByRole("link", {
-        name: "Personal collection a",
-      }).should("exist");
+        name: "Ian's source data set",
+      }).should("be.visible");
     });
 
     it("should show the 'Your recent tools' section with tools", () => {
@@ -151,12 +207,12 @@ describe("Homepage dashboard", () => {
       cy.findByRole("heading", {
         level: 2,
         name: "Your recent tools",
-      }).should("exist");
+      }).should("be.visible");
       cy.findAllByRole("link", { name: "Visit tools" }).should("not.exist");
       cy.findAllByRole("link", { name: "Find out more about tools" }).should(
         "not.exist"
       );
-      cy.findByRole("link", { name: "Superset" }).should("exist");
+      cy.findByRole("link", { name: "Superset" }).should("be.visible");
     });
 
     it("should show the 'Your bookmarks' section with bookmarks", () => {
@@ -164,11 +220,15 @@ describe("Homepage dashboard", () => {
       cy.findByRole("heading", {
         level: 2,
         name: "Your bookmarks",
-      }).should("exist");
+      }).should("be.visible");
       cy.findByTestId("your-bookmarks").within(($form) => {
-        cy.findByRole("link", { name: "Source dataset" }).should("exist");
+        cy.findByRole("link", { name: "Some bookmarked dataset" }).should(
+          "exist"
+        );
       });
-      cy.findByRole("link", { name: "View all bookmarks" }).should("exist");
+      cy.findByRole("link", { name: "View all bookmarks" }).should(
+        "be.visible"
+      );
     });
   });
 });

--- a/cypress/fixtures/datasets.ts
+++ b/cypress/fixtures/datasets.ts
@@ -4,10 +4,12 @@ export const datacutWithTableAndLinks = "b603337f-0073-43ac-9dc4-05a8d5cf635d";
 export const sourceWithTable = "3112a785-6bd9-4e56-bc67-10b6cccb5db7";
 export const sourceWithTableNoPermissions =
   "d7094267-ddfc-40f3-a4a8-ca4f30a0992f";
+export const sourceWithTableNoAccess = "7533af71-45ec-49fc-92c8-03d421af7250";
 
 export type DataCatalogueIDType =
   | typeof datacutWithNoPermissions
   | typeof datacutWithLinks
   | typeof datacutWithTableAndLinks
   | typeof sourceWithTable
-  | typeof sourceWithTableNoPermissions;
+  | typeof sourceWithTableNoPermissions
+  | typeof sourceWithTableNoAccess;

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -1,0 +1,12 @@
+declare namespace Cypress {
+  interface Chainable {
+    /**
+     * Custom command to select DOM element by data-cy attribute.
+     * @example cy.dataCy('greeting')
+     */
+    setUsersEditorAccess(
+      dataSetId: string,
+      hasEditorAccess: boolean
+    ): Chainable<Element>;
+  }
+}

--- a/cypress/support/assertions.ts
+++ b/cypress/support/assertions.ts
@@ -80,10 +80,21 @@ const assertDataAccessNotification = (id: DataCatalogueIDType) => {
   );
 };
 
+const assertSuccessNotification = (message: string) => {
+  cy.findByRole("heading", {
+    name: "Success",
+    level: 2,
+  }).should("be.visible");
+  cy.findByRole("alert").within(() => {
+    cy.findByText(message).should("be.visible");
+  });
+};
+
 export {
   assertTable,
   assertTextAndLinks,
   assertDatasetTitle,
   assertLinksToManageDataset,
   assertDataAccessNotification,
+  assertSuccessNotification,
 };

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,3 +1,20 @@
 import "@testing-library/cypress/add-commands";
 import "./setup-cypress-testing-library";
 /// <reference types="cypress" />
+
+Cypress.Commands.add("setUsersEditorAccess", (dataSetId, hasEditorAccess) => {
+  // First go to home page to pick up CSRF cookie
+  cy.visit("/");
+  cy.getCookie("data_workspace_csrf").then((c) =>
+    cy.request({
+      url: `/test/dataset/${dataSetId}`,
+      method: "PATCH",
+      headers: {
+        "X-CSRFToken": c.value,
+      },
+      body: {
+        data_catalogue_editors: [hasEditorAccess ? 2 : 1],
+      },
+    })
+  );
+});

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "lib": ["es5", "dom"],
-    "types": ["cypress", "node", "@testing-library/cypress"]
+    "types": ["cypress", "node", "@testing-library/cypress", "./support"]
   },
   "include": ["**/*.ts"]
 }

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1936,15 +1936,17 @@ class DataSetReviewAccess(EditBaseView, FormView):
             absolute_url = self.request.build_absolute_uri(
                 reverse("datasets:dataset_detail", args=[self.obj.id])
             )
-            send_email(
-                settings.NOTIFY_DATASET_ACCESS_GRANTED_TEMPLATE_ID,
-                user.email,
-                personalisation={
-                    "email_address": user.email,
-                    "dataset_name": self.obj.name,
-                    "dataset_url": absolute_url,
-                },
-            )
+            # In Dev Ignore the API call to Zendesk and notify
+            if settings.ENVIRONMENT != "Dev":
+                send_email(
+                    settings.NOTIFY_DATASET_ACCESS_GRANTED_TEMPLATE_ID,
+                    user.email,
+                    personalisation={
+                        "email_address": user.email,
+                        "dataset_name": self.obj.name,
+                        "dataset_url": absolute_url,
+                    },
+                )
             messages.success(
                 self.request,
                 f"An email has been sent to {user.first_name} {user.last_name} to let them know they now have access.",
@@ -1953,15 +1955,17 @@ class DataSetReviewAccess(EditBaseView, FormView):
             AccessRequest.objects.all().filter(requester_id=user.id).update(
                 data_access_status="declined"
             )
-            send_email(
-                settings.NOTIFY_DATASET_ACCESS_DENIED_TEMPLATE_ID,
-                user.email,
-                personalisation={
-                    "email_address": user.email,
-                    "dataset_name": self.obj.name,
-                    "deny_reasoning": form.cleaned_data["message"],
-                },
-            )
+            # In Dev Ignore the API call to Zendesk and notify
+            if settings.ENVIRONMENT != "Dev":
+                send_email(
+                    settings.NOTIFY_DATASET_ACCESS_DENIED_TEMPLATE_ID,
+                    user.email,
+                    personalisation={
+                        "email_address": user.email,
+                        "dataset_name": self.obj.name,
+                        "deny_reasoning": form.cleaned_data["message"],
+                    },
+                )
             messages.success(
                 self.request,
                 f"An email has been sent to {user.first_name} {user.last_name} to let them know their access request was not successful.",  # pylint: disable=line-too-long
@@ -2089,14 +2093,18 @@ class DatasetRemoveAuthorisedUserView(EditBaseView, View):
             url_dataset = request.build_absolute_uri(
                 reverse("datasets:dataset_detail", args=[self.obj.pk])
             )
-            send_email(
-                settings.NOTIFY_DATASET_ACCESS_REMOVE_TEMPLATE_ID,
-                user.email,
-                personalisation={
-                    "dataset_name": name_dataset,
-                    "dataset_url": url_dataset,
-                },
-            )
+
+            # In Dev Ignore the API call to Zendesk and notify
+            if settings.ENVIRONMENT != "Dev":
+                send_email(
+                    settings.NOTIFY_DATASET_ACCESS_REMOVE_TEMPLATE_ID,
+                    user.email,
+                    personalisation={
+                        "dataset_name": name_dataset,
+                        "dataset_url": url_dataset,
+                    },
+                )
+
         return HttpResponseRedirect(
             reverse(
                 "datasets:edit_permissions_summary",

--- a/dataworkspace/dataworkspace/apps/request_access/views.py
+++ b/dataworkspace/dataworkspace/apps/request_access/views.py
@@ -192,8 +192,12 @@ class AccessRequestConfirmationPage(RequestAccessMixin, DetailView):
             if access_request.catalogue_item_id
             else None
         )
-        if not access_request.zendesk_reference_number:
 
+        # In Dev Ignore the API call to Zendesk and notify
+        if settings.ENVIRONMENT == "Dev":
+            return super().get(request, *args, **kwargs)
+
+        if not access_request.zendesk_reference_number:
             if waffle.flag_is_active(request, settings.ALLOW_REQUEST_ACCESS_TO_DATA_FLOW):
                 if (
                     isinstance(catalogue_item, VisualisationCatalogueItem)

--- a/dataworkspace/dataworkspace/apps/test_endpoints/datasets/serializers.py
+++ b/dataworkspace/dataworkspace/apps/test_endpoints/datasets/serializers.py
@@ -1,0 +1,14 @@
+from rest_framework import serializers
+
+from dataworkspace.apps.datasets.models import (
+    DataSet,
+)
+
+
+class DatasetSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DataSet
+        fields = (
+            "id",
+            "data_catalogue_editors",
+        )

--- a/dataworkspace/dataworkspace/apps/test_endpoints/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/test_endpoints/datasets/urls.py
@@ -1,0 +1,10 @@
+from dataworkspace.apps.test_endpoints.datasets import views
+from django.urls import path
+
+urlpatterns = [
+    path(
+        "dataset/<uuid:pk>",
+        views.DatasetViewSet.as_view({"patch": "partial_update"}),
+        name="update",
+    )
+]

--- a/dataworkspace/dataworkspace/apps/test_endpoints/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/test_endpoints/datasets/views.py
@@ -1,0 +1,22 @@
+from rest_framework import status, mixins
+from rest_framework.viewsets import GenericViewSet
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from dataworkspace.apps.datasets.models import (
+    DataSet,
+)
+from .serializers import DatasetSerializer
+
+
+class DatasetViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, GenericViewSet):
+    queryset = DataSet.objects.all()
+    serializer_class = DatasetSerializer
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def perform_update(self, serializer):
+        data_catalogue_editors = serializer.validated_data.get("data_catalogue_editors")
+        serializer.save(data_catalogue_editors=data_catalogue_editors)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/dataworkspace/dataworkspace/apps/test_endpoints/urls.py
+++ b/dataworkspace/dataworkspace/apps/test_endpoints/urls.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+from django.urls import include, path
+
+urlpatterns = []
+
+if settings.ENVIRONMENT == "Dev":
+    urlpatterns += [
+        path(
+            "",
+            include(
+                ("dataworkspace.apps.test_endpoints.datasets.urls", "test"), namespace="dataset"
+            ),
+        ),
+    ]

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -110,6 +110,7 @@ INSTALLED_APPS = [
     "dataworkspace.apps.dw_admin",
     "dataworkspace.apps.api_v1",
     "dataworkspace.apps.api_v2",
+    "dataworkspace.apps.test_endpoints",
     "dataworkspace.apps.eventlog",
     "dataworkspace.apps.request_data",
     "dataworkspace.apps.request_access",

--- a/dataworkspace/dataworkspace/static/js/react/features/confirm-remove-user/ConfirmRemoveUser.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/confirm-remove-user/ConfirmRemoveUser.tsx
@@ -74,7 +74,7 @@ const ConfirmRemoveUser = ({
                       onClick={() => openModal(user)}
                       style={{ marginBottom: 0 }}
                     >
-                      Remove User
+                      Remove user
                     </Button>
                   </Table.Cell>
                 )}

--- a/dataworkspace/dataworkspace/static/js/react/features/confirm-remove-user/ConfirmRemoveUser.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/confirm-remove-user/ConfirmRemoveUser.tsx
@@ -23,13 +23,12 @@ type User = {
 };
 
 const UserTypeSuffix: React.FC<Record<'user', User>> = function ({ user }) {
-  let user_type_suffix = '';
   if (user.iam) {
-    user_type_suffix = '(Information Asset Manager)';
+    return '(Information Asset Manager)';
   } else if (user.iao) {
-    user_type_suffix = '(Information Asset Owner)';
+    return '(Information Asset Owner)';
   }
-  return <>{user_type_suffix}</>;
+  return null;
 };
 
 const ConfirmRemoveUser = ({

--- a/dataworkspace/dataworkspace/static/js/react/features/confirm-remove-user/ConfirmRemoveUser.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/confirm-remove-user/ConfirmRemoveUser.tsx
@@ -22,15 +22,14 @@ type User = {
   remove_user_url: string;
 };
 
-const populateUserTypeSuffix = function (user: User) {
+const UserTypeSuffix: React.FC<Record<'user', User>> = function ({ user }) {
   let user_type_suffix = '';
   if (user.iam) {
-    user_type_suffix += '(Information Asset Manager) ';
+    user_type_suffix = '(Information Asset Manager)';
+  } else if (user.iao) {
+    user_type_suffix = '(Information Asset Owner)';
   }
-  if (user.iao) {
-    user_type_suffix += '(Information Asset Owner)';
-  }
-  return user_type_suffix.trim();
+  return <>{user_type_suffix}</>;
 };
 
 const ConfirmRemoveUser = ({
@@ -58,7 +57,7 @@ const ConfirmRemoveUser = ({
               <Table.Row key={user.id}>
                 <Table.Cell style={{ paddingBottom: '1px' }}>
                   <SpanBold>{`${user.first_name} ${user.last_name} `}</SpanBold>
-                  {populateUserTypeSuffix(user)}
+                  <UserTypeSuffix user={user} />
                   <Paragraph>{user.email}</Paragraph>
                 </Table.Cell>
                 {[user.iam, user.iao].some((x) => x == true) ? (

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4463,6 +4463,7 @@ class TestDatasetEditView:
 
     @mock.patch("dataworkspace.apps.datasets.views.send_email")
     @override_flag(settings.ALLOW_REQUEST_ACCESS_TO_DATA_FLOW, active=True)
+    @override_settings(ENVIRONMENT="Production")
     def test_remove_removes_user_from_authorized_users_summary(
         self, mock_send_email, client, user
     ):
@@ -5230,6 +5231,7 @@ class TestDatasetReviewAccessApproval:
             )
 
     @mock.patch("dataworkspace.apps.datasets.views.send_email")
+    @override_settings(ENVIRONMENT="Production")
     def test_master_dataset_approval_with_email_sent(self, mock_send_email):
         self.setUp()
         response = self.client.post(
@@ -5262,6 +5264,7 @@ class TestDatasetReviewAccessApproval:
         )
 
     @mock.patch("dataworkspace.apps.datasets.views.send_email")
+    @override_settings(ENVIRONMENT="Production")
     def test_datacut_dataset_approval_with_email_sent(self, mock_send_email):
         self.setUp(name="Datacut", dataset_type=DataSetType.DATACUT)
         response = self.client.post(
@@ -5294,6 +5297,7 @@ class TestDatasetReviewAccessApproval:
         )
 
     @mock.patch("dataworkspace.apps.datasets.views.send_email")
+    @override_settings(ENVIRONMENT="Production")
     def test_visualisation_dataset_approval_with_email_sent(self, mock_send_email):
         self.setUp(is_visualisation=True)
         response = self.client.post(
@@ -5326,6 +5330,7 @@ class TestDatasetReviewAccessApproval:
         )
 
     @override_flag(settings.ALLOW_REQUEST_ACCESS_TO_DATA_FLOW, active=True)
+    @override_settings(ENVIRONMENT="Production")
     @mock.patch("dataworkspace.apps.datasets.views.send_email")
     def test_master_dataset_access_denied_with_email_sent(self, mock_send_email):
         self.setUp()
@@ -5362,6 +5367,7 @@ class TestDatasetReviewAccessApproval:
         )
 
     @override_flag(settings.ALLOW_REQUEST_ACCESS_TO_DATA_FLOW, active=True)
+    @override_settings(ENVIRONMENT="Production")
     @mock.patch("dataworkspace.apps.datasets.views.send_email")
     def test_datacut_dataset_access_denied_with_email_sent(self, mock_send_email):
         self.setUp(name="Datacut", dataset_type=DataSetType.DATACUT)
@@ -5398,6 +5404,7 @@ class TestDatasetReviewAccessApproval:
         )
 
     @mock.patch("dataworkspace.apps.datasets.views.send_email")
+    @override_settings(ENVIRONMENT="Production")
     def test_visualisation_dataset_access_denied_with_email_sent(self, mock_send_email):
         self.setUp(is_visualisation=True)
         factories.PendingAuthorizedUsersFactory.create(

--- a/dataworkspace/dataworkspace/tests/request_access/test_views.py
+++ b/dataworkspace/dataworkspace/tests/request_access/test_views.py
@@ -6,7 +6,7 @@ import pytest
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import Client
+from django.test import Client, override_settings
 from django.urls import reverse
 
 from dataworkspace.apps.applications.models import ApplicationInstance
@@ -96,6 +96,7 @@ class TestDatasetAccessOnly:
     @pytest.mark.django_db
     @mock.patch("dataworkspace.apps.request_access.views.zendesk.Zenpy")
     @mock.patch("dataworkspace.apps.core.storage._upload_to_clamav")
+    @override_settings(ENVIRONMENT="Production")
     def test_zendesk_ticket_created_after_form_submission(
         self, mock_upload_to_clamav, mock_zendesk_client, client, user, metadata_db
     ):
@@ -288,6 +289,7 @@ class TestToolsAccessOnly:
     @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.request_access.views.zendesk.Zenpy")
     @mock.patch("dataworkspace.apps.core.storage._upload_to_clamav")
+    @override_settings(ENVIRONMENT="Production")
     def test_zendesk_ticket_created_after_form_submission(
         self,
         mock_upload_to_clamav,

--- a/dataworkspace/dataworkspace/urls.py
+++ b/dataworkspace/dataworkspace/urls.py
@@ -155,6 +155,10 @@ urlpatterns = [
         include(("dataworkspace.apps.api_v2.urls", "api_v2"), namespace="api-v2"),
     ),
     path(
+        "test/",
+        include(("dataworkspace.apps.test_endpoints.urls", "test"), namespace="test"),
+    ),
+    path(
         "admin/",
         include(("dataworkspace.apps.dw_admin.urls", "dw_admin"), namespace="dw-admin"),
     ),

--- a/dataworkspace/e2e_fixtures.json
+++ b/dataworkspace/e2e_fixtures.json
@@ -27,8 +27,8 @@
       "username": "20a0353f-a7d1-4851-9af8-1bcaff152b60",
       "first_name": "Vyvyan",
       "last_name": "Holland",
-      "email": "vyvyan.holland@contact-email.com",
-      "is_staff": true,
+      "email": "vyvyan.holland@businessandtrade.gov.uk",
+      "is_staff": false,
       "is_active": true,
       "date_joined": "2024-01-04T12:53:52.272Z",
       "groups": [],
@@ -54,7 +54,9 @@
       "tools_access_role_arn": "",
       "sso_status": "active",
       "home_directory_efs_access_point_id": null,
-      "first_login": "2024-01-04T12:53:52.321Z"
+      "first_login": "2024-01-04T12:53:52.321Z",
+      "tools_certification_date": null,
+      "is_renewal_email_sent": false
     }
   },
   {
@@ -66,29 +68,25 @@
       "tools_access_role_arn": "",
       "sso_status": "active",
       "home_directory_efs_access_point_id": null,
-      "first_login": "2024-01-04T12:53:52.321Z"
+      "first_login": "2024-01-04T12:53:52.321Z",
+      "tools_certification_date": null,
+      "is_renewal_email_sent": false
     }
   },
   {
     "model": "datasets.sensitivitytype",
     "pk": 1,
-    "fields": {
-      "name": "PERSONAL"
-    }
+    "fields": { "name": "PERSONAL" }
   },
   {
     "model": "datasets.sensitivitytype",
     "pk": 2,
-    "fields": {
-      "name": "COMMERCIAL"
-    }
+    "fields": { "name": "COMMERCIAL" }
   },
   {
     "model": "datasets.sensitivitytype",
     "pk": 3,
-    "fields": {
-      "name": "LOCSEN"
-    }
+    "fields": { "name": "LOCSEN" }
   },
   {
     "model": "datasets.dataset",
@@ -118,7 +116,7 @@
       "published_at": "2024-01-12",
       "dictionary_published": true,
       "eligibility_criteria": null,
-      "number_of_downloads": 78,
+      "number_of_downloads": 92,
       "information_asset_owner": 1,
       "information_asset_manager": 1,
       "reference_code": null,
@@ -131,6 +129,7 @@
       "search_vector_english_description": "'ad':22 'adipisc':7 'aliqua':19 'aliquip':32 'amet':5 'commodo':35 'consectetur':6 'consequat':36 'dolor':3,17 'ea':34 'eiusmod':11 'elit':8 'enim':21 'et':16 'ex':33 'exercit':27 'incididunt':13 'ipsum':2 'labor':15 'labori':29 'lorem':1 'magna':18 'minim':23 'nisi':30 'nostrud':26 'qui':25 'sed':9 'sit':4 'tempor':12 'ullamco':28 'ut':14,20,31 'veniam':24",
       "average_unique_users_daily": 0.0,
       "government_security_classification": 1,
+      "esda": false,
       "tags": [],
       "data_catalogue_editors": [],
       "sensitivity": [2]
@@ -177,6 +176,7 @@
       "search_vector_english_description": "'ad':22 'adipisc':7 'aliqua':19 'aliquip':32 'amet':5 'commodo':35 'consectetur':6 'consequat':36 'dolor':3,17 'ea':34 'eiusmod':11 'elit':8 'enim':21 'et':16 'ex':33 'exercit':27 'incididunt':13 'ipsum':2 'labor':15 'labori':29 'lorem':1 'magna':18 'minim':23 'nisi':30 'nostrud':26 'qui':25 'sed':9 'sit':4 'tempor':12 'ullamco':28 'ut':14,20,31 'veniam':24",
       "average_unique_users_daily": 0.0,
       "government_security_classification": 1,
+      "esda": false,
       "tags": [],
       "data_catalogue_editors": [],
       "sensitivity": []
@@ -223,9 +223,57 @@
       "search_vector_english_description": "'ad':22 'adipisc':7 'aliqua':19 'aliquip':32 'amet':5 'commodo':35 'consectetur':6 'consequat':36 'dolor':3,17 'ea':34 'eiusmod':11 'elit':8 'enim':21 'et':16 'ex':33 'exercit':27 'incididunt':13 'ipsum':2 'labor':15 'labori':29 'lorem':1 'magna':18 'minim':23 'nisi':30 'nostrud':26 'qui':25 'sed':9 'sit':4 'tempor':12 'ullamco':28 'ut':14,20,31 'veniam':24",
       "average_unique_users_daily": 0.0,
       "government_security_classification": 1,
+      "esda": false,
       "tags": [],
       "data_catalogue_editors": [],
       "sensitivity": [2]
+    }
+  },
+  {
+    "model": "datasets.dataset",
+    "pk": "7533af71-45ec-49fc-92c8-03d421af7250",
+    "fields": {
+      "created_date": "2024-11-15T14:43:07.444Z",
+      "modified_date": "2024-11-15T14:43:07.444Z",
+      "deleted": false,
+      "created_by": 2,
+      "updated_by": 2,
+      "type": 1,
+      "name": "Source dataset - access request",
+      "slug": "source-dataset-access-request",
+      "short_description": "This is a short description about a source dataset",
+      "grouping": null,
+      "description": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>",
+      "notes": "",
+      "acronyms": "",
+      "enquiries_contact": 1,
+      "licence": "No licence",
+      "licence_url": "http://some-url.com",
+      "retention_policy": "Records are retained for 10 years after the form was submitted",
+      "personal_data": null,
+      "restrictions_on_usage": "",
+      "user_access_type": "REQUIRES_AUTHORIZATION",
+      "published": true,
+      "published_at": "2024-11-15",
+      "dictionary_published": false,
+      "eligibility_criteria": null,
+      "number_of_downloads": 0,
+      "information_asset_owner": 1,
+      "information_asset_manager": 1,
+      "reference_code": null,
+      "authorized_email_domains": "[]",
+      "request_approvers": null,
+      "search_vector_english": "'access':3A 'ad':35 'adipisc':20 'aliqua':32 'aliquip':45 'amet':18 'commodo':48 'consectetur':19 'consequat':49 'dataset':2A,13B 'descript':9B 'dolor':16,30 'ea':47 'eiusmod':24 'elit':21 'enim':34 'et':29 'ex':46 'exercit':40 'incididunt':26 'ipsum':15 'labor':28 'labori':42 'lorem':14 'magna':31 'minim':36 'nisi':43 'nostrud':39 'qui':38 'request':4A 'sed':22 'short':8B 'sit':17 'sourc':1A,12B 'tempor':25 'ullamco':41 'ut':27,33,44 'veniam':37",
+      "search_vector_english_name": "'access':3 'dataset':2 'request':4 'sourc':1",
+      "search_vector_english_short_description": "'dataset':9 'descript':5 'short':4 'sourc':8",
+      "search_vector_english_tags": "",
+      "search_vector_english_description": "'ad':22 'adipisc':7 'aliqua':19 'aliquip':32 'amet':5 'commodo':35 'consectetur':6 'consequat':36 'dolor':3,17 'ea':34 'eiusmod':11 'elit':8 'enim':21 'et':16 'ex':33 'exercit':27 'incididunt':13 'ipsum':2 'labor':15 'labori':29 'lorem':1 'magna':18 'minim':23 'nisi':30 'nostrud':26 'qui':25 'sed':9 'sit':4 'tempor':12 'ullamco':28 'ut':14,20,31 'veniam':24",
+      "average_unique_users_daily": 0.0,
+      "government_security_classification": 1,
+      "esda": false,
+      "tags": [],
+      "data_catalogue_editors": [],
+      "sensitivity": []
     }
   },
   {
@@ -269,6 +317,7 @@
       "search_vector_english_description": "'ad':22 'adipisc':7 'aliqua':19 'aliquip':32 'amet':5 'commodo':35 'consectetur':6 'consequat':36 'dolor':3,17 'ea':34 'eiusmod':11 'elit':8 'enim':21 'et':16 'ex':33 'exercit':27 'incididunt':13 'ipsum':2 'labor':15 'labori':29 'lorem':1 'magna':18 'minim':23 'nisi':30 'nostrud':26 'qui':25 'sed':9 'sit':4 'tempor':12 'ullamco':28 'ut':14,20,31 'veniam':24",
       "average_unique_users_daily": 0.0,
       "government_security_classification": 1,
+      "esda": false,
       "tags": [],
       "data_catalogue_editors": [],
       "sensitivity": [2]
@@ -315,6 +364,7 @@
       "search_vector_english_description": "'ad':22 'adipisc':7 'aliqua':19 'aliquip':32 'amet':5 'commodo':35 'consectetur':6 'consequat':36 'dolor':3,17 'ea':34 'eiusmod':11 'elit':8 'enim':21 'et':16 'ex':33 'exercit':27 'incididunt':13 'ipsum':2 'labor':15 'labori':29 'lorem':1 'magna':18 'minim':23 'nisi':30 'nostrud':26 'qui':25 'sed':9 'sit':4 'tempor':12 'ullamco':28 'ut':14,20,31 'veniam':24",
       "average_unique_users_daily": 0.0,
       "government_security_classification": null,
+      "esda": false,
       "tags": [],
       "data_catalogue_editors": [],
       "sensitivity": []
@@ -361,6 +411,7 @@
       "search_vector_english_description": "'ad':22 'adipisc':7 'aliqua':19 'aliquip':32 'amet':5 'commodo':35 'consectetur':6 'consequat':36 'dolor':3,17 'ea':34 'eiusmod':11 'elit':8 'enim':21 'et':16 'ex':33 'exercit':27 'incididunt':13 'ipsum':2 'labor':15 'labori':29 'lorem':1 'magna':18 'minim':23 'nisi':30 'nostrud':26 'qui':25 'sed':9 'sit':4 'tempor':12 'ullamco':28 'ut':14,20,31 'veniam':24",
       "average_unique_users_daily": 0.0,
       "government_security_classification": 2,
+      "esda": false,
       "tags": [],
       "data_catalogue_editors": [],
       "sensitivity": [2]
@@ -407,6 +458,7 @@
       "search_vector_english_description": "'ad':22 'adipisc':7 'aliqua':19 'aliquip':32 'amet':5 'commodo':35 'consectetur':6 'consequat':36 'dolor':3,17 'ea':34 'eiusmod':11 'elit':8 'enim':21 'et':16 'ex':33 'exercit':27 'incididunt':13 'ipsum':2 'labor':15 'labori':29 'lorem':1 'magna':18 'minim':23 'nisi':30 'nostrud':26 'qui':25 'sed':9 'sit':4 'tempor':12 'ullamco':28 'ut':14,20,31 'veniam':24",
       "average_unique_users_daily": 0.0,
       "government_security_classification": 1,
+      "esda": false,
       "tags": [],
       "data_catalogue_editors": [],
       "sensitivity": [2]
@@ -495,6 +547,27 @@
   },
   {
     "model": "datasets.sourcetable",
+    "pk": "2708f1a1-9a6c-4b2f-b580-1ab0bcb14879",
+    "fields": {
+      "created_date": "2024-11-15T14:43:07.587Z",
+      "modified_date": "2024-11-15T14:43:07.587Z",
+      "dataset": "7533af71-45ec-49fc-92c8-03d421af7250",
+      "reference_number": null,
+      "name": "source_data_set",
+      "database": "ac99394d-336c-4de9-8c9f-c5bd38d0b670",
+      "schema": "public",
+      "frequency": 1,
+      "table": "test_dataset",
+      "dataset_finder_opted_in": false,
+      "data_grid_enabled": true,
+      "data_grid_download_enabled": false,
+      "data_grid_download_limit": null,
+      "disable_data_grid_interaction": false,
+      "published": true
+    }
+  },
+  {
+    "model": "datasets.sourcetable",
     "pk": "f29eef9f-4cfb-467a-a475-38928d3f0e32",
     "fields": {
       "created_date": "2024-02-22T08:27:15.788Z",
@@ -517,42 +590,32 @@
   {
     "model": "datasets.datasetuserpermission",
     "pk": 1,
-    "fields": {
-      "user": 2,
-      "dataset": "161d4b68-4b0d-4d96-80dc-d2f9867ff515"
-    }
+    "fields": { "user": 2, "dataset": "161d4b68-4b0d-4d96-80dc-d2f9867ff515" }
   },
   {
     "model": "datasets.datasetuserpermission",
     "pk": 2,
-    "fields": {
-      "user": 2,
-      "dataset": "406291aa-e35e-41a9-ab05-6355c5cc92d6"
-    }
+    "fields": { "user": 2, "dataset": "406291aa-e35e-41a9-ab05-6355c5cc92d6" }
   },
   {
     "model": "datasets.datasetuserpermission",
     "pk": 3,
-    "fields": {
-      "user": 2,
-      "dataset": "b603337f-0073-43ac-9dc4-05a8d5cf635d"
-    }
+    "fields": { "user": 2, "dataset": "b603337f-0073-43ac-9dc4-05a8d5cf635d" }
   },
   {
     "model": "datasets.datasetuserpermission",
     "pk": 4,
-    "fields": {
-      "user": 2,
-      "dataset": "3112a785-6bd9-4e56-bc67-10b6cccb5db7"
-    }
+    "fields": { "user": 2, "dataset": "3112a785-6bd9-4e56-bc67-10b6cccb5db7" }
   },
   {
     "model": "datasets.datasetuserpermission",
     "pk": 5,
-    "fields": {
-      "user": 1,
-      "dataset": "f66c88c3-b6de-4c18-921f-8cd409861eab"
-    }
+    "fields": { "user": 1, "dataset": "f66c88c3-b6de-4c18-921f-8cd409861eab" }
+  },
+  {
+    "model": "datasets.datasetuserpermission",
+    "pk": 6,
+    "fields": { "user": 1, "dataset": "7533af71-45ec-49fc-92c8-03d421af7250" }
   },
   {
     "model": "datasets.sourceview",
@@ -656,95 +719,6 @@
       "owner": 2,
       "notes": null,
       "user_access_type": "REQUIRES_AUTHORIZATION"
-    }
-  },
-  {
-    "model": "eventlog.eventlog",
-    "pk": 3239,
-    "fields": {
-      "user": 2,
-      "timestamp": "2024-02-22T10:47:41.066Z",
-      "event_type": 28,
-      "content_type": 33,
-      "object_id": "3112a785-6bd9-4e56-bc67-10b6cccb5db7",
-      "extra": {
-        "path": "/datasets/3112a785-6bd9-4e56-bc67-10b6cccb5db7",
-        "reference_dataset_version": "2024-01-12"
-      }
-    }
-  },
-  {
-    "model": "eventlog.eventlog",
-    "pk": 3240,
-    "fields": {
-      "user": 2,
-      "timestamp": "2024-02-22T10:47:56.204Z",
-      "event_type": 28,
-      "content_type": 33,
-      "object_id": "f66c88c3-b6de-4c18-921f-8cd409861eab",
-      "extra": {
-        "path": "/datasets/f66c88c3-b6de-4c18-921f-8cd409861eab",
-        "reference_dataset_version": "2024-02-21"
-      }
-    }
-  },
-  {
-    "model": "eventlog.eventlog",
-    "pk": 3241,
-    "fields": {
-      "user": 2,
-      "timestamp": "2024-02-22T10:48:02.720Z",
-      "event_type": 28,
-      "content_type": 33,
-      "object_id": "161d4b68-4b0d-4d96-80dc-d2f9867ff515",
-      "extra": {
-        "path": "/datasets/161d4b68-4b0d-4d96-80dc-d2f9867ff515",
-        "reference_dataset_version": "2024-01-12"
-      }
-    }
-  },
-  {
-    "model": "eventlog.eventlog",
-    "pk": 3242,
-    "fields": {
-      "user": 2,
-      "timestamp": "2024-02-22T10:48:08.070Z",
-      "event_type": 28,
-      "content_type": 33,
-      "object_id": "406291aa-e35e-41a9-ab05-6355c5cc92d6",
-      "extra": {
-        "path": "/datasets/406291aa-e35e-41a9-ab05-6355c5cc92d6",
-        "reference_dataset_version": "2024-01-12"
-      }
-    }
-  },
-  {
-    "model": "eventlog.eventlog",
-    "pk": 3243,
-    "fields": {
-      "user": 2,
-      "timestamp": "2024-02-22T10:48:13.578Z",
-      "event_type": 28,
-      "content_type": 33,
-      "object_id": "d7094267-ddfc-40f3-a4a8-ca4f30a0992f",
-      "extra": {
-        "path": "/datasets/d7094267-ddfc-40f3-a4a8-ca4f30a0992f",
-        "reference_dataset_version": "2024-01-12"
-      }
-    }
-  },
-  {
-    "model": "eventlog.eventlog",
-    "pk": 3244,
-    "fields": {
-      "user": 2,
-      "timestamp": "2024-02-22T10:48:30.633Z",
-      "event_type": 48,
-      "content_type": null,
-      "object_id": null,
-      "extra": {
-        "tool": "Superset"
-      }
     }
   }
 ]

--- a/dataworkspace/start-e2e.sh
+++ b/dataworkspace/start-e2e.sh
@@ -21,6 +21,7 @@ set -e
     django-admin waffle_flag ACCESSIBLE_AUTOCOMPLETE_FLAG --everyone --create
     django-admin waffle_flag SUGGESTED_SEARCHES_FLAG --everyone --create
     django-admin waffle_flag TOOLS_SELF_CERTIFY --everyone --create
+    django-admin waffle_flag ALLOW_REQUEST_ACCESS_TO_DATA_FLOW --everyone --create
 
     # nginx is configured to log to stdout/stderr, _except_ before
     # it manages to read its config file. To avoid errors on startup,


### PR DESCRIPTION
### Description of change

Ticket [DT-2389](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-2389)

This change adds E2E tests running against the new data access request feature. As I have needed to change the users profile status between test suites I have also created a new endpoint in this PR that can be used to add/remove editorial the users editorial access against any dataset. 


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Have E2E tests been added to cover any React changes?
* [x] Have Accessibility tests been added to cover any React changes?

[DT-2389]: https://uktrade.atlassian.net/browse/DT-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ