### PR TITLE
DT-2423 add manual 'Add User' button to manage permissions page

### DIFF
--- a/dataworkspace/dataworkspace/static/js/react/features/confirm-remove-user/ConfirmRemoveUser.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/confirm-remove-user/ConfirmRemoveUser.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 
 import { Button } from '@govuk-react/button';
-import { H2 } from '@govuk-react/heading';
 import Table from '@govuk-react/table';
 import { Paragraph } from 'govuk-react';
 import styled from 'styled-components';
@@ -42,10 +41,9 @@ const ConfirmRemoveUser = ({
   return (
     <>
       {data.length < 1 ? (
-        <H2>There are currently no authorized users</H2>
+        <div></div>
       ) : (
         <div>
-          <H2>Users who have access</H2>
           <Table>
             {data.map((user) => (
               <Table.Row key={user.id}>

--- a/dataworkspace/dataworkspace/templates/datasets/manage_permissions/edit_access.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manage_permissions/edit_access.html
@@ -46,7 +46,7 @@
       <h1 class="govuk-heading-xl">Manage access to {{ obj.name }}</h1>
       {% if requested_users %} 
         <table class="govuk-table govuk-!-margin-bottom-8">
-          <h2 class="govuk-heading-m">Users who have requested access</h2>
+          <h2 class="govuk-heading-l">Users who have requested access</h2>
               <tbody class="govuk-table__body">
                   {% for user in requested_users %} 
                   <tr class="govuk-table__row">
@@ -57,8 +57,15 @@
                   <td class="govuk-table__cell govuk-!-text-align-right"><a class="govuk-link" href="#">Review access request</a></td>
                   </tr>
               {% endfor %}
-          </tbody>
+              
         </table> 
+        <h2 class="govuk-heading-l">Users who have access</h2>
+        <td class="govuk-table__cell"><button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"><a class="govuk-link" href="{% url 'datasets:remove_authorized_user' obj.id summary.id user.id %}"></a>Add User</button></td>
+        <tbody class="govuk-table__body">
+                {% if authorised_users.count == 0 %}
+                  <h2 class="govuk-heading-m">There are currently no authorized users</h2>
+                {% endif %}
+            </tbody>
         {% endif %}
         {% include "partials/react-slot-data.html" with mount_id="confirm-remove-user" data=authorised_users test_id="confirm-remove-user" %}
       <div class="govuk-body">

--- a/dataworkspace/dataworkspace/templates/datasets/manage_permissions/edit_access.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manage_permissions/edit_access.html
@@ -59,14 +59,18 @@
               {% endfor %}
               
         </table> 
+        {% endif %}
         <h2 class="govuk-heading-l">Users who have access</h2>
-        <td class="govuk-table__cell"><button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"><a class="govuk-link" href="{% url 'datasets:remove_authorized_user' obj.id summary.id user.id %}"></a>Add User</button></td>
+        <button type="submit" class="govuk-button govuk-button--secondary"><a class="govuk-link" href="{% url 'datasets:search_authorized_users' obj.id summary_id %}"></a>Add User</button>
+        <a class="govuk-link" href="{% url 'datasets:search_authorized_users' obj.id summary_id %}">Add User</a>
+        <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+          <a class="govuk-link" href="{% url 'datasets:search_authorized_users' obj.id summary.id %}">Add User</a>
+        </button>
         <tbody class="govuk-table__body">
                 {% if authorised_users.count == 0 %}
                   <h2 class="govuk-heading-m">There are currently no authorized users</h2>
                 {% endif %}
             </tbody>
-        {% endif %}
         {% include "partials/react-slot-data.html" with mount_id="confirm-remove-user" data=authorised_users test_id="confirm-remove-user" %}
       <div class="govuk-body">
           <a class="govuk-link" href="{% url 'datasets:dataset_detail' obj.id %}">View catalogue page</a>

--- a/dataworkspace/dataworkspace/templates/datasets/manage_permissions/edit_access.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manage_permissions/edit_access.html
@@ -61,16 +61,14 @@
         </table> 
         {% endif %}
         <h2 class="govuk-heading-l">Users who have access</h2>
-        <button type="submit" class="govuk-button govuk-button--secondary"><a class="govuk-link" href="{% url 'datasets:search_authorized_users' obj.id summary_id %}"></a>Add User</button>
-        <a class="govuk-link" href="{% url 'datasets:search_authorized_users' obj.id summary_id %}">Add User</a>
-        <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-          <a class="govuk-link" href="{% url 'datasets:search_authorized_users' obj.id summary.id %}">Add User</a>
-        </button>
-        <tbody class="govuk-table__body">
+          <a class="govuk-link" href="{% url 'datasets:search_authorized_users' obj.id summary.id %}"><button type="submit" class="govuk-button govuk-button--secondary govuk-!-static-margin-bottom-6" data-module="govuk-button">
+            Add User
+          </button></a>
+    
                 {% if authorised_users.count == 0 %}
                   <h2 class="govuk-heading-m">There are currently no authorized users</h2>
                 {% endif %}
-            </tbody>
+          
         {% include "partials/react-slot-data.html" with mount_id="confirm-remove-user" data=authorised_users test_id="confirm-remove-user" %}
       <div class="govuk-body">
           <a class="govuk-link" href="{% url 'datasets:dataset_detail' obj.id %}">View catalogue page</a>


### PR DESCRIPTION
Button introduced to Manage Permissions page to allow IAM/IAOs to manually add users to datasets. 

Will be redirected to the search feature of the particular dataset. 