### PR TITLE
feat/dt-2433: Guard against adding a user that already exists

### DIFF
--- a/cypress/e2e/datasets/add-remove-access.cy.ts
+++ b/cypress/e2e/datasets/add-remove-access.cy.ts
@@ -5,7 +5,7 @@ import {
 
 import { sourceWithTableNoAccess } from "../../fixtures/datasets";
 
-describe("Adding and removing access to a dataset", () => {
+describe("Adding and removing user access to a dataset", () => {
   context("when I view the manage access page", () => {
     before(() => {
       cy.setUsersEditorAccess(sourceWithTableNoAccess, true);
@@ -26,6 +26,38 @@ describe("Adding and removing access to a dataset", () => {
       });
     });
   });
+
+  context("when I search for users", () => {
+    beforeEach(() => {
+      cy.setUsersEditorAccess(sourceWithTableNoAccess, true);
+      cy.visit(`datasets/${sourceWithTableNoAccess}/edit-permissions`);
+    });
+    it("should show a search title for one user", () => {
+      cy.findByRole("button", { name: "Add users" })
+        .should("be.visible")
+        .click();
+      cy.findByRole("textbox", {
+        name: "Search by email address or name",
+      })
+        .should("be.visible")
+        .type("vyvyan");
+      cy.findByRole("button", { name: "Search" }).should("be.visible").click();
+      cy.findByText("Found 1 matching user for vyvyan").should("be.visible");
+    });
+    it("should show a search title for multiple users", () => {
+      cy.findByRole("button", { name: "Add users" })
+        .should("be.visible")
+        .click();
+      cy.findByRole("textbox", {
+        name: "Search by email address or name",
+      })
+        .should("be.visible")
+        .type("businessandtrade");
+      cy.findByRole("button", { name: "Search" }).should("be.visible").click();
+      cy.findByText("Found 2 matching users").should("be.visible");
+    });
+  });
+
   context("when I search and add a user", () => {
     before(() => {
       cy.setUsersEditorAccess(sourceWithTableNoAccess, true);
@@ -57,13 +89,9 @@ describe("Adding and removing access to a dataset", () => {
         "An email has been sent to Vyvyan Holland to let them know they now have access."
       );
     });
-  });
-  context("when I view the manage access page", () => {
-    before(() => {
+    it("should show two users that have access", () => {
       cy.setUsersEditorAccess(sourceWithTableNoAccess, true);
       cy.visit(`datasets/${sourceWithTableNoAccess}/edit-permissions`);
-    });
-    it("should show two users that has access", () => {
       cy.findByRole("heading", {
         name: "Manage access to Source dataset - access request",
         level: 1,
@@ -79,6 +107,32 @@ describe("Adding and removing access to a dataset", () => {
       });
     });
   });
+
+  context("when I search and try to add a user that already has access", () => {
+    before(() => {
+      cy.setUsersEditorAccess(sourceWithTableNoAccess, true);
+      cy.visit(`datasets/${sourceWithTableNoAccess}/edit-permissions`);
+    });
+    it("should display one user with a label that says they already has access", () => {
+      cy.findByRole("button", { name: "Add users" })
+        .should("be.visible")
+        .click();
+
+      cy.findByRole("textbox", {
+        name: "Search by email address or name",
+      })
+        .should("be.visible")
+        .type("vyvyan");
+      cy.findByRole("button", { name: "Search" }).should("be.visible").click();
+      cy.get("table").within(() => {
+        cy.get("tr").should("have.length", 1);
+        cy.get("td").contains("Vyvyan Holland");
+        cy.get("td").contains("User is already a member");
+      });
+      cy.findAllByRole("button", { name: "Add user" }).should("not.exist");
+    });
+  });
+
   context("when I remove the users data access", () => {
     beforeEach(() => {
       cy.visit(`datasets/${sourceWithTableNoAccess}/edit-permissions`);

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1645,7 +1645,24 @@ class UserSearchFormView(EditBaseView, FormView):
                     users = get_user_model().objects.filter(
                         email__istartswith=search_query.split("@")[0]
                     )
-                context["search_results"] = users
+                if isinstance(self.obj, DataSet):
+                    permissions = DataSetUserPermission.objects.filter(dataset=self.obj)
+                else:
+                    permissions = VisualisationUserPermission.objects.filter(visualisation=self.obj)
+
+                users_with_permission = [p.user.id for p in permissions]
+                search_results = []
+
+                for user in users:
+                    search_results.append({
+                        "id": user.id,
+                        "first_name": user.first_name,
+                        "last_name": user.last_name,
+                        "email": user.email,
+                        "has_access": user.id in users_with_permission
+                    })
+
+                context["search_results"] = search_results
             context["search_query"] = search_query
         context["obj"] = self.obj
         context["obj_edit_url"] = (

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1648,19 +1648,23 @@ class UserSearchFormView(EditBaseView, FormView):
                 if isinstance(self.obj, DataSet):
                     permissions = DataSetUserPermission.objects.filter(dataset=self.obj)
                 else:
-                    permissions = VisualisationUserPermission.objects.filter(visualisation=self.obj)
+                    permissions = VisualisationUserPermission.objects.filter(
+                        visualisation=self.obj
+                    )
 
                 users_with_permission = [p.user.id for p in permissions]
                 search_results = []
 
                 for user in users:
-                    search_results.append({
-                        "id": user.id,
-                        "first_name": user.first_name,
-                        "last_name": user.last_name,
-                        "email": user.email,
-                        "has_access": user.id in users_with_permission
-                    })
+                    search_results.append(
+                        {
+                            "id": user.id,
+                            "first_name": user.first_name,
+                            "last_name": user.last_name,
+                            "email": user.email,
+                            "has_access": user.id in users_with_permission,
+                        }
+                    )
 
                 context["search_results"] = search_results
             context["search_query"] = search_query

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -102,7 +102,7 @@
         {% else %}
          <div class="govuk-grid-column-full">
           <table class="govuk-table">
-              <caption class="govuk-table__caption govuk-table__caption--m govuk-!-margin-bottom-0">Found {{ search_results.count }} matching user{% if search_results.count > 1 %}s{% else %} for {{ search_query }}{% endif %}</caption>
+              <caption class="govuk-table__caption govuk-table__caption--m govuk-!-margin-bottom-0">Found {{ search_results|length }} matching user{% if search_results|length > 1 %}s{% else %} for {{ search_query }}{% endif %}</caption>
               <tbody class="govuk-table__body">
                   {% for result in search_results %}
                   <tr class="govuk-table__row">
@@ -111,7 +111,11 @@
                         <td class="govuk-table__cell table-cell--text-align-right">
                           <form action="{% url 'datasets:add_authorized_user' obj.id summary_id result.id %}" method="post" novalidate>
                             {% csrf_token %}
-                            <button type="submit" class="govuk-button govuk-!-margin-bottom-0">Add user</button>
+                            {% if result.has_access %}
+                              User is already a member
+                            {% else %}
+                              <button type="submit" class="govuk-button govuk-!-margin-bottom-0">Add user</button>
+                            {% endif %}
                           </form>
                         </td>
                       {% else %}


### PR DESCRIPTION
### Description of change
Ticket [DT-2433](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-2433)

When you are searching for users to add to a dataset permissions list you don't want to add a user that already has access. Although there is no harm in this its better to show the label "User is already a member" than surfacing a button that will add them again. This change adds that label so you know who already has access.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Have E2E tests been added to cover any React changes?
* [x] Have Accessibility tests been added to cover any React changes?

[DT-2433]: https://uktrade.atlassian.net/browse/DT-2433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ