### PR TITLE
Correcting CSV guidance

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/add_table/upload_csv.html
+++ b/dataworkspace/dataworkspace/templates/datasets/add_table/upload_csv.html
@@ -20,7 +20,8 @@ Add Table - {{ model.name }} - {{ block.super }}{% endblock %}
             <ul class="govuk-list govuk-list--bullet">
                 <li>the file has more than one row</li>
                 <li>there are no special characters in the file name (e.g. /*? ) apart from underscores and hyphens</li>
-                <li>Google Sheets documents are downloaded as a standard CSV file</li>
+                <li>the file type is CSV UTF-8 (comma delimited) instead of any other CSV file type</li>
+                <li>Google Sheets documents are downloaded as CSV UTF-8 (comma delimited)</li>
             </ul>
             <h2 class="govuk-heading-m">Check your formatting in Excel</h2>
             <p class="govuk-body">Check that:</p>

--- a/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/add_table/test_views.py
@@ -564,7 +564,7 @@ class TestUploadCSVPage(TestCase):
             "Check your CSV against each of the below points. This can help you avoid common issues when the table is being built."
             in paragraph_one_text
         )
-        assert len(bullet_point_text) + len(bullet_point_text_two) == 5
+        assert len(bullet_point_text) + len(bullet_point_text_two) == 6
 
     def test_csv_upload_fails_when_it_contains_special_chars(self):
         file1 = SimpleUploadedFile(


### PR DESCRIPTION
Text updated to:

Check that:
- the file has more than one row
- there are no special characters in the file name (e.g. /*? ) apart from underscores and hyphens
- the file type is CSV UTF-8 (comma delimited) instead of any other CSV file type
- Google Sheets documents are downloaded as CSV UTF-8 (comma delimited)