### PR TITLE
[DRAFT] feat: add source and publisher tags to CatalogueItemSerializer

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
@@ -41,6 +41,8 @@ class CatalogueItemSerializer(serializers.Serializer):
     information_asset_manager = serializers.IntegerField()
     enquiries_contact = serializers.IntegerField()
     source_tags = serializers.ListField()
+    publisher_tags = serializers.ListField()
+    topic_tags = serializers.ListField()
     licence = serializers.CharField()
     personal_data = serializers.CharField()
     retention_policy = serializers.CharField()
@@ -69,6 +71,8 @@ class CatalogueItemSerializer(serializers.Serializer):
         )
         instance["purpose"] = _PURPOSES[int(instance["purpose"])]
         instance["source_tags"] = instance["source_tags"] or None
+        instance["publisher_tags"] = instance["publisher_tags"] or None
+        instance["topic_tags"] = instance["topic_tags"] or None
         instance["licence"] = instance["licence"] or None
         instance["personal_data"] = instance["personal_data"] or None
         instance["retention_policy"] = instance["retention_policy"] or None

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
@@ -332,6 +332,8 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
         "slug",
         "purpose",
         "source_tags",
+        "publisher_tags",
+        "topic_tags",
         "draft",
         "dictionary",
         "personal_data",
@@ -355,6 +357,20 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
             source_tags=ArrayAgg(
                 "tags__name",
                 filter=models.Q(tags__type=TagType.SOURCE),
+                distinct=True,
+            )
+        )
+        .annotate(
+            publisher_tags=ArrayAgg(
+                "tags__name",
+                filter=models.Q(tags__type=TagType.PUBLISHER),
+                distinct=True,
+            )
+        )
+        .annotate(
+            topic_tags=ArrayAgg(
+                "tags__name",
+                filter=models.Q(tags__type=TagType.TOPIC),
                 distinct=True,
             )
         )
@@ -403,6 +419,20 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
                     distinct=True,
                 )
             )
+            .annotate(
+                publisher_tags=ArrayAgg(
+                    "tags__name",
+                    filter=models.Q(tags__type=TagType.PUBLISHER),
+                    distinct=True,
+                )
+            )
+            .annotate(
+                topic_tags=ArrayAgg(
+                    "tags__name",
+                    filter=models.Q(tags__type=TagType.TOPIC),
+                    distinct=True,
+                )
+            )
             .annotate(user_ids=Value([], output_field=ArrayField(models.IntegerField())))
             .annotate(draft=F("is_draft"))
             .annotate(dictionary=F("published"))
@@ -427,6 +457,20 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
                 source_tags=ArrayAgg(
                     "tags__name",
                     filter=models.Q(tags__type=TagType.SOURCE),
+                    distinct=True,
+                )
+            )
+            .annotate(
+                publisher_tags=ArrayAgg(
+                    "tags__name",
+                    filter=models.Q(tags__type=TagType.PUBLISHER),
+                    distinct=True,
+                )
+            )
+            .annotate(
+                topic_tags=ArrayAgg(
+                    "tags__name",
+                    filter=models.Q(tags__type=TagType.TOPIC),
                     distinct=True,
                 )
             )

--- a/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
@@ -21,7 +21,7 @@ from dataworkspace.apps.datasets.models import (
 )
 from dataworkspace.tests import factories
 from dataworkspace.tests.api_v1.base import BaseAPIViewTest
-from dataworkspace.apps.datasets.constants import DataSetType
+from dataworkspace.apps.datasets.constants import DataSetType, TagType
 
 
 def flush_database(connection):
@@ -466,7 +466,21 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
             "dictionary_published": getattr(dataset, "dictionary_published", None),
             "licence": dataset.licence or None,
             "purpose": purpose,
-            "source_tags": [t.name for t in dataset.tags.all()] if dataset.tags.all() else None,
+            "source_tags": (
+                [t.name for t in dataset.tags.all() if t.type == TagType.SOURCE]
+                if dataset.tags.all()
+                else None
+            ),
+            "publisher_tags": (
+                [t.name for t in dataset.tags.all() if t.type == TagType.PUBLISHER]
+                if dataset.tags.all()
+                else None
+            ),
+            "topic_tags": (
+                [t.name for t in dataset.tags.all() if t.type == TagType.TOPIC]
+                if dataset.tags.all()
+                else None
+            ),
             "personal_data": personal_data,
             "retention_policy": retention_policy,
             "eligibility_criteria": list(eligibility_criteria) if eligibility_criteria else None,
@@ -507,7 +521,13 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
                 eligibility_criteria=["eligibility"],
             )
         datacut.data_catalogue_editors.set([catalogue_editor])
-        datacut.tags.set([factories.SourceTagFactory()])
+        datacut.tags.set(
+            [
+                factories.SourceTagFactory(),
+                factories.TopicTagFactory(),
+                factories.PublisherTagFactory(),
+            ]
+        )
 
         with freeze_time("2020-01-01 00:01:00"):
             master_dataset = factories.MasterDataSetFactory(


### PR DESCRIPTION
### Description of change

Add source and publisher tags to CatalogueItemSerializer to enrich data-flow ingestion detailed here: https://github.com/uktrade/data-flow/pull/4271

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?