### PR TITLE
feat: add tool tag management to Django admin

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/admin.py
+++ b/dataworkspace/dataworkspace/apps/applications/admin.py
@@ -394,6 +394,8 @@ class ToolTemplateAdmin(admin.ModelAdmin):
                     "group_name",
                     "application_summary",
                     "application_help_link",
+                    "tag",
+                    "tag_extra_css_class",
                     "spawner",
                     "spawner_time",
                     "spawner_options",


### PR DESCRIPTION
### Description of change

This adds the ability to manage tag and tag_extra_css_class from Django admin. It was an oversight to omit this from the earlier change that added the fields.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?