### PR TITLE
fix: update breadcrumb and fix wrapping

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/manage_permissions/review_access.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manage_permissions/review_access.html
@@ -5,7 +5,7 @@
 
 {% block breadcrumbs %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <div class="govuk-grid-column-full">
       <div class="govuk-breadcrumbs">
         <ol class="govuk-breadcrumbs__list">
           <li class="govuk-breadcrumbs__list-item">
@@ -18,7 +18,7 @@
             <a class="govuk-breadcrumbs__link" href="{{ obj_edit_url }}">Manage this dataset</a>
           </li>
           <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-breadcrumbs__link" href="{{obj_manage_url}}">Manage permissions</a>
+            <a class="govuk-breadcrumbs__link" href="{{obj_manage_url}}">Manage access</a>
           </li>
             <li class="govuk-breadcrumbs__list-item">
             Review

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -5110,7 +5110,6 @@ class TestDatasetReviewAccess:
         header_one = soup.find("h1")
         requester_section_header = header_one.find_next_sibling("h2")
         requester_section_name = requester_section_header.find_next_sibling("p")
-        requester_section_email = requester_section_name.find_next_sibling("p")
         requester_reason_section_header = soup.find_all("h2")[1]
         requester_reason_section_reason = requester_reason_section_header.find_next_sibling("p")
 
@@ -5126,8 +5125,7 @@ class TestDatasetReviewAccess:
         assert response.status_code == 200
         assert header_one.get_text() == "Review Bob Testerten's access to Master"
         assert requester_section_header.get_text() == "Requestor"
-        assert requester_section_name.get_text() == "Bob Testerten"
-        assert requester_section_email.get_text() == "bob.testerten@contact-email.com"
+        assert requester_section_name.get_text() == "Bob Testertenbob.testerten@contact-email.com"
         assert requester_reason_section_header.get_text() == "Requestor's reason for access"
         assert requester_reason_section_reason.get_text() == "I need it"
 


### PR DESCRIPTION
### Description of change
This change updates a link in the breadcrumb for the data request access journey and stops the last link wrapping.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?