### PR TITLE
fix: catch correct error type

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError
 from csp.decorators import csp_update
 from django.conf import settings
 from django.contrib import messages
+from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
@@ -1855,10 +1856,10 @@ class DatasetEditPermissionsSummaryView(EditBaseView, TemplateView):
             )
 
             requested_users = []
-
+            User = get_user_model()
             for request in requests:
                 try:
-                    user = get_user_model().objects.get(email=request.contact_email)
+                    user = User.objects.get(email=request.contact_email)
                     requested_users.append(
                         {
                             "id": user.id,
@@ -1871,8 +1872,8 @@ class DatasetEditPermissionsSummaryView(EditBaseView, TemplateView):
                             + 1,
                         }
                     )
-                except get_user_model().DoesNotExist:
-                    logger.exception(
+                except ObjectDoesNotExist:
+                    logger.error(
                         "User with email: %s no longer exists.", request.contact_email
                     )
                     continue

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1873,9 +1873,7 @@ class DatasetEditPermissionsSummaryView(EditBaseView, TemplateView):
                         }
                     )
                 except ObjectDoesNotExist:
-                    logger.error(
-                        "User with email: %s no longer exists.", request.contact_email
-                    )
+                    logger.error("User with email: %s no longer exists.", request.contact_email)
                     continue
 
             context["requested_users"] = requested_users

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -5539,7 +5539,7 @@ class TestDatasetEditPermissionsSummaryView:
         assert "bob.testerten@contact-email.com" in user_access_request
 
     @override_flag(settings.ALLOW_REQUEST_ACCESS_TO_DATA_FLOW, active=True)
-    @mock.patch("logging.Logger.exception")
+    @mock.patch("logging.Logger.error")
     def test_access_requests_do_not_display_when_non_users_exist(self, mock_logger):
         self.setUp(email="bob.testerten@some-email.com")
         response = self.client.get(


### PR DESCRIPTION
### Description of change
This change makes sure we are catching the correct exception type when a user cannot be found when managing permissions.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?