### PR TITLE
fix: catch all error types when managing permissions

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1874,9 +1874,9 @@ class DatasetEditPermissionsSummaryView(EditBaseView, TemplateView):
                     )
                 except ObjectDoesNotExist:
                     logger.error("User with email: %s no longer exists.", request.contact_email)
+                    continue
                 except MultipleObjectsReturned:
                     logger.error("More than one %s returned", request.contact_email)
-                finally:
                     continue
 
             context["requested_users"] = requested_users

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -12,7 +12,7 @@ from botocore.exceptions import ClientError
 from csp.decorators import csp_update
 from django.conf import settings
 from django.contrib import messages
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
@@ -1874,6 +1874,9 @@ class DatasetEditPermissionsSummaryView(EditBaseView, TemplateView):
                     )
                 except ObjectDoesNotExist:
                     logger.error("User with email: %s no longer exists.", request.contact_email)
+                except MultipleObjectsReturned:
+                    logger.error("More than one %s returned", request.contact_email)
+                finally:
                     continue
 
             context["requested_users"] = requested_users

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1859,7 +1859,7 @@ class DatasetEditPermissionsSummaryView(EditBaseView, TemplateView):
             User = get_user_model()
             for request in requests:
                 try:
-                    user = User.objects.get(email=request.contact_email)
+                    user = User.objects.get(email=request.contact_email, is_active=True)
                     requested_users.append(
                         {
                             "id": user.id,


### PR DESCRIPTION
### Description of change
This change guards against two scenarios that can crop up when managing access requests. 

1. The user has left the department so the query tries to look up an object that doesn't exist
2. There is a possibility that there are duplicate emails so now we only return the active one.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?