### PR TITLE
feat: simplify ECR tagging

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -146,9 +146,14 @@ def application_template_tag_user_commit_from_host(public_host):
 
     matching = matching_tools + matching_visualisations
 
-    # Visualisations are all in the same docker repo with different tags,
-    # while tools are each in their own repo
-    tag = public_host if matching_visualisations else None
+    # Visualisations are all in the same docker repo with different tags and so we need to set the
+    # tag, while tools are each in their own repo and we take the tag from its task definition
+    if commit_id and matching_visualisations:
+        tag = public_host
+    elif not commit_id and matching_visualisations:
+        tag = public_host + "--prod"
+    else:
+        tag = None
 
     if not matching:
         raise ApplicationTemplate.DoesNotExist()


### PR DESCRIPTION
### Description of change

This change:

- Stops adding the suffix-less tag of just the visualisation name to ECR images
- And stops using this tag in favour of the tag with the "--prod" suffix, which was added in a previous change

While not technically required, it makes releasing just a tiny bit more robust, because it is now atomic, and makes it easier to reason about the tags when looking in ECR, for example when debugging future issues.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?