### PR TITLE
fix/DT-2525: make sure zendesk tickets and emails are sent

### DIFF
--- a/dataworkspace/dataworkspace/apps/request_access/views.py
+++ b/dataworkspace/dataworkspace/apps/request_access/views.py
@@ -175,7 +175,7 @@ class AccessRequestConfirmationPage(RequestAccessMixin, DetailView):
 
         if not access_request.zendesk_reference_number:
             if waffle.flag_is_active(request, settings.ALLOW_REQUEST_ACCESS_TO_DATA_FLOW):
-                if (isinstance(catalogue_item, (DataSet, VisualisationCatalogueItem))):
+                if isinstance(catalogue_item, (DataSet, VisualisationCatalogueItem)):
                     access_request.zendesk_reference_number = (
                         zendesk.notify_dataset_access_request(
                             request,

--- a/dataworkspace/dataworkspace/apps/request_access/views.py
+++ b/dataworkspace/dataworkspace/apps/request_access/views.py
@@ -175,11 +175,7 @@ class AccessRequestConfirmationPage(RequestAccessMixin, DetailView):
 
         if not access_request.zendesk_reference_number:
             if waffle.flag_is_active(request, settings.ALLOW_REQUEST_ACCESS_TO_DATA_FLOW):
-                if (
-                    isinstance(catalogue_item, VisualisationCatalogueItem)
-                    and catalogue_item.visualisation_template is not None
-                    or isinstance(catalogue_item, DataSet)
-                ):
+                if (isinstance(catalogue_item, (DataSet, VisualisationCatalogueItem))):
                     access_request.zendesk_reference_number = (
                         zendesk.notify_dataset_access_request(
                             request,


### PR DESCRIPTION
Ticket: [DT-2525](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-2525)

Currently some users are getting a false positive around access requests. For some reason we were restricting access requests to visualisations if the visualisation catalogue item didn't have a gitlab template attached. This change makes sure a user can still ask for access on a visualisation catalogue even when the template does not exist.

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?

[DT-2525]: https://uktrade.atlassian.net/browse/DT-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ