### PR TITLE
fix/add initial backend view and url route DO NOT MERGE

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/views.py
+++ b/dataworkspace/dataworkspace/apps/core/views.py
@@ -16,6 +16,7 @@ from django.http import (
 )
 from django.shortcuts import render
 from django.urls import reverse
+from django.utils.timezone import now, timedelta
 from django.views import View
 from django.views.generic import FormView
 from requests import HTTPError
@@ -463,3 +464,17 @@ class ContactUsView(FormView):
         if cleaned["contact_type"] == form.ContactTypes.GET_HELP:
             return HttpResponseRedirect(reverse("support"))
         return HttpResponseRedirect(reverse("feedback"))
+
+
+class SetNotificationCookie(View):
+    def post(self, request, *args, **kwargs):
+        # id_campaign = request.POST.get("id_campaign")
+        id_campaign = "placholder"
+        # config_notification_banner = NotificationBannerConfig.objects.filter(campaign_id=id_campaign)
+        # date_expiry = config_notification_banner.expiry_date
+        date_expiry = now() + timedelta(days=1)
+        if now() >= date_expiry:
+            response = JsonResponse({"message": f"campaign {id_campaign} expired"})
+        else:
+            action = request.POST.get("action")
+            response.set_cookie(f"{id_campaign}_{action}", "true", expires=date_expiry)

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -174,9 +174,31 @@ def _get_tags_as_dict():
     return tags_dict
 
 
+def show_survey_banner(request):
+    accepted = request.COOKIES.get("survey_accepted")
+    dismissed = request.COOKIES.get("suvery_dismissed")
+    # neither accepted nor dismissed
+    if all(s is None for s in [accepted, dismissed]):
+        return True
+    # dismissed and accepted could both be true so check accepted first
+    elif accepted is not None:
+        return False
+    elif dismissed is not None:
+        # config_notification = NotificationConfig.Objects.filter(campaign_id="survey") or simply NofiticationConfig.Objects.first()
+        date_expiry = datetime.strptime("2025/03/03", "%H/%m/%d")  # config_notifaction.expiry_date
+        cookie_expiration = datetime.strptime(
+            request.COOKIES.get("survey_dismissed_expiration"), "%Y-%m-%dT%%H:%M:%S"
+        )
+        # is is the last week?
+        days_left = (cookie_expiration - datetime.now()).days
+        if days_left <= 7:
+            return True
+    return False
+
+
 @csp_update(SCRIPT_SRC=settings.WEBPACK_SCRIPT_SRC)
 def home_view(request):
-    return render(request, "datasets/index.html")
+    return render(request, "datasets/index.html", {"show_survey": show_survey_banner(request)})
 
 
 @csp_update(SCRIPT_SRC=settings.WEBPACK_SCRIPT_SRC)

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -38,7 +38,9 @@
     )
   </script>
 {% endblock %}
-
+{% if show_survey %}
+<!-- suvery goes around here somewhere? -->
+{% endif %}
 {% block page_title %}Search - {{ block.super }}{% endblock %}
 {% block search_bar %}
 <div class="app-site-search__container">

--- a/dataworkspace/dataworkspace/urls.py
+++ b/dataworkspace/dataworkspace/urls.py
@@ -19,6 +19,7 @@ from dataworkspace.apps.core.views import (
     CustomVisualisationReviewView,
     NewsletterSubscriptionView,
     RestoreTableDAGTaskStatusView,
+    SetNotificationCookie,
     ServeS3UploadedFileView,
     SupportAnalysisDatasetView,
     SupportView,
@@ -199,6 +200,14 @@ urlpatterns = [
         "restore-table/status/<str:execution_date>/<str:task_id>",
         login_required(RestoreTableDAGTaskStatusView.as_view()),
         name="restore-table-task-status",
+    ),
+    path(
+        "restore-table/status/<str:execution_date>/<str:task_id>",
+        login_required(RestoreTableDAGTaskStatusView.as_view()),
+        name="restore-table-task-status",
+    ),
+    path(
+        "set-notification-cookie/", SetNotificationCookie.as_view(), name="set_notification_cookie"
     ),
 ]
 


### PR DESCRIPTION
### Description of change
Rough outline of how we could use the accepted/dimissed cookie. We could call the backend with js* or turn the survey into a django form.

* _e.g._
``` js
<link id="accepted" onclick="closeBanner(true)">
<link id="dismissed" onclick="closeBanner(false)">

<script>
const closeBanner = function(hasAccepted) {
const status = "accepted" ? hasAccepted : "dismissed"; 
post("set-notification-cookie", args={status=status, campaign="survey"}) // etc etc
}
</script>