### PR TITLE
Show link to docker build logs when visualisation preview fails

### DIFF
--- a/dataworkspace/dataworkspace/templates/errors/error_500_visualisation_docker_build.html
+++ b/dataworkspace/dataworkspace/templates/errors/error_500_visualisation_docker_build.html
@@ -1,0 +1,15 @@
+{% extends '_main.html' %}
+
+{% block page_title %}Your visualisation failed to build - {{ block.super }}{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Your visualisation failed to build</h1>
+
+        <p class="govuk-body">Visit the <a href="{{ build_log_url }}" class="govuk-link">Docker build logs</a> for more information.</p>
+
+        <p class="govuk-body">If you're unable to resolve the issue, please <a class="govuk-link" href="{% url 'support' %}">contact the Data Workspace Support Team</a>.</p>
+      </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
### Description of change
This changes the error message shown to the users when visualisation preview fails.  It previously showed a generic error page with a cryptic Application Stopped message.

This now shows relevant 'Your visualisation failed to build' message along with a link to docker build logs

This doesn't yet tackle other failures during visualisation life cycle.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?