### PR TITLE
fix/dynamic date in tools access request e2e

### DIFF
--- a/cypress/e2e/tools/tools-access.cy.ts
+++ b/cypress/e2e/tools/tools-access.cy.ts
@@ -245,7 +245,7 @@ describe('Tools access', () => {
   context('When a user successfully submits the form', () => {
     it('should show a success message and have access to tools', () => {
       cy.visit('/request-access/self-certify');
-      setCertificateDate('01', '02', '2024');
+      setCertificateDate('01', '01', new Date().getFullYear().toString());
       acceptDeclaration();
       cy.findByRole('button', { name: 'Submit' }).click();
       cy.findByRole('alert').within(() => {


### PR DESCRIPTION
### Description of change

e2e tools access year needs to be a year within the current date else the test fails. It's usually bad policy to have dynamic values in test however I think this is an ok exception as:
- It's just a way of testing all the other test cases and all it needs to be is a valid value in the date-range.
- We would have to keep manually tweaking each time it goes out of date (annually, so not frequent but still a pain).