### PR TITLE
feat/DT-2601: Display a list of approvers - Owner view

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/fixtures/project_member_fixture.json
+++ b/dataworkspace/dataworkspace/apps/applications/fixtures/project_member_fixture.json
@@ -1,8 +1,8 @@
 [
   {
     "id": 1,
-    "name": "Ian Leggett",
-    "username": "ian.leggett",
+    "name": "Vyvyan Holland",
+    "username": "vyvyan.holland",
     "state": "active",
     "access_level": 40
   }

--- a/dataworkspace/dataworkspace/apps/applications/fixtures/project_members_fixture.json
+++ b/dataworkspace/dataworkspace/apps/applications/fixtures/project_members_fixture.json
@@ -1,8 +1,8 @@
 [
   {
     "id": 1,
-    "name": "Ian Leggett",
-    "username": "ian.leggett",
+    "name": "Vyvyan Holland",
+    "username": "vyvyan.holland",
     "state": "active",
     "access_level": 40
   },
@@ -16,6 +16,13 @@
   {
     "id": 3,
     "name": "James Robinson",
+    "username": "james.robinson",
+    "state": "active",
+    "access_level": 30
+  },
+  {
+    "id": 4,
+    "name": "Bob Testerten",
     "username": "james.robinson",
     "state": "active",
     "access_level": 30

--- a/dataworkspace/dataworkspace/apps/applications/fixtures/user_fixture.json
+++ b/dataworkspace/dataworkspace/apps/applications/fixtures/user_fixture.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 1,
-    "name": "Ian Leggett",
-    "username": "ian.leggett"
+    "name": "Vyvyan Holland",
+    "username": "vyvyan.holland"
   }
 ]

--- a/dataworkspace/dataworkspace/templates/applications/visualisation_approvals.html
+++ b/dataworkspace/dataworkspace/templates/applications/visualisation_approvals.html
@@ -17,7 +17,16 @@
   </h1>
 {% flag THIRD_APPROVER %}
    <p class="govuk-body">Currently {{ approvals | length }} out of 3 have approved this visualisation.</p>
-  {% if is_owner  %}
+     <ul class="govuk-list govuk-list--bullet" data-test="approvals-list">
+      {% for approver in approvals %}
+        {% if approver.status == 'team member' %}
+        <li>A member of the Data Workspace team approved this visualisation on {{ approver.date_approved }}</li>
+        {% else %}
+         <li>{% if request.user.get_full_name == approver %}You{% else %}{{ approver.name }} ({{approver.status}}){% endif %} approved this visualisation at {{ approver.date_approved }}</li>
+        {% endif %}
+      {% endfor %}
+   </ul>
+  {% if type_of_user.is_owner  %}
      {% include './visualisation_approvals/owner.html' %}
    {% endif %}
    <h2 class="govuk-heading-m">Approve this visualisation</h2>


### PR DESCRIPTION
### Description of change

This change follows on from #3465 and adds the logic needed to display the users that have approved a visualisation.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?