### PR TITLE
feat: separate common and non common tables when generating credentials

### DIFF
--- a/dataworkspace/dataworkspace/apps/accounts/management/commands/store_db_creds_in_s3.py
+++ b/dataworkspace/dataworkspace/apps/accounts/management/commands/store_db_creds_in_s3.py
@@ -26,11 +26,13 @@ class Command(BaseCommand):
         for user in all_users:
             self.stdout.write(f"Creating credentials for {user.email}")
 
-            source_tables = source_tables_for_user(user)
+            source_tables_user_non_common, source_tables_user_common = source_tables_for_user(user)
+
             db_role_schema_suffix = db_role_schema_suffix_for_user(user)
             creds = new_private_database_credentials(
                 db_role_schema_suffix,
-                source_tables,
+                source_tables_user_non_common,
+                source_tables_user_common,
                 postgres_user(user.email),
                 user,
                 valid_for=datetime.timedelta(days=31),

--- a/dataworkspace/dataworkspace/apps/api_v1/core/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/core/views.py
@@ -96,13 +96,18 @@ def get_superset_credentials(request):
         # Give "editor"/"admin" users temp private credentials
         else:
             dashboards_user_can_access = []
-            source_tables = source_tables_for_user(dw_user)
+
+            source_tables_user_non_common, source_tables_user_common = source_tables_for_user(
+                dw_user
+            )
+
             db_role_schema_suffix = stable_identification_suffix(
                 str(dw_user.profile.sso_id), short=True
             )
             credentials = new_private_database_credentials(
                 db_role_schema_suffix,
-                source_tables,
+                source_tables_user_non_common,
+                source_tables_user_common,
                 postgres_user(dw_user.email, suffix="superset"),
                 dw_user,
                 valid_for=duration,

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -62,7 +62,7 @@ def spawn(
     user = get_user_model().objects.get(pk=user_id)
     application_instance = ApplicationInstance.objects.get(id=application_instance_id)
 
-    (source_tables, db_role_schema_suffix, db_user) = (
+    ((source_tables, source_tables_common), db_role_schema_suffix, db_user) = (
         (
             source_tables_for_user(user),
             db_role_schema_suffix_for_user(user),
@@ -79,6 +79,7 @@ def spawn(
     credentials = new_private_database_credentials(
         db_role_schema_suffix,
         source_tables,
+        source_tables_common,
         db_user,
         user if application_instance.application_template.application_type == "TOOL" else None,
         valid_for=datetime.timedelta(days=31),

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -1434,8 +1434,13 @@ def _datasets(user, application_template):
     # to reverse the change, which may need urgent contact with support to
     # restore access
 
-    source_tables_user = source_tables_for_user(user)
-    source_tables_app = source_tables_for_app(application_template)
+    source_tables_user_non_common, source_tables_user_common = source_tables_for_user(user)
+    source_tables_user = source_tables_user_non_common + source_tables_user_common
+
+    source_tables_app_non_common, source_tables_app_common = source_tables_for_app(
+        application_template
+    )
+    source_tables_app = source_tables_app_non_common + source_tables_app_common
 
     selectable_dataset_ids = set(
         source_table["dataset"]["id"]

--- a/dataworkspace/dataworkspace/apps/explorer/utils.py
+++ b/dataworkspace/dataworkspace/apps/explorer/utils.py
@@ -178,14 +178,19 @@ def get_user_explorer_connection_settings(user, alias):
 
             if not user_credentials:
                 db_role_schema_suffix = db_role_schema_suffix_for_user(user)
-                source_tables = source_tables_for_user(user)
+
+                source_tables_user_non_common, source_tables_user_common = source_tables_for_user(
+                    user
+                )
+
                 db_user = postgres_user(user.email, suffix="explorer")
                 duration = timedelta(hours=24)
                 cache_duration = (duration - timedelta(minutes=15)).total_seconds()
 
                 user_credentials = new_private_database_credentials(
                     db_role_schema_suffix,
-                    source_tables,
+                    source_tables_user_non_common,
+                    source_tables_user_common,
                     db_user,
                     user,
                     valid_for=duration,

--- a/dataworkspace/dataworkspace/tests/api_v1/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/core/test_views.py
@@ -36,6 +36,8 @@ class TestGetSupersetCredentialsAPIView:
         ]
         mock_new_credentials.return_value = credentials
 
+        mock_source_tables.return_value = ([], [])
+
         user = factories.UserFactory()
         tools_permission = Permission.objects.get(
             codename="start_all_applications",

--- a/dataworkspace/dataworkspace/tests/core/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/core/test_utils.py
@@ -108,11 +108,12 @@ class TestPostgresUser:
         user_count = DatabaseUser.objects.count()
 
         user = factories.UserFactory()
-        source_tables = source_tables_for_user(user)
+        source_tables_user_non_common, source_tables_user_common = source_tables_for_user(user)
         db_role_schema_suffix = db_role_schema_suffix_for_user(user)
         new_private_database_credentials(
             db_role_schema_suffix,
-            source_tables,
+            source_tables_user_non_common,
+            source_tables_user_common,
             user.email,
             user,
             valid_for=datetime.timedelta(days=31),
@@ -133,11 +134,12 @@ class TestNewPrivateDatabaseCredentials:
             )
         )
 
-        source_tables = source_tables_for_user(user)
+        source_tables_user_non_common, source_tables_user_common = source_tables_for_user(user)
         db_role_schema_suffix = db_role_schema_suffix_for_user(user)
         user_creds_to_drop = new_private_database_credentials(
             db_role_schema_suffix,
-            source_tables,
+            source_tables_user_non_common,
+            source_tables_user_common,
             postgres_user(user.email),
             user,
             valid_for=datetime.timedelta(days=1),
@@ -165,25 +167,28 @@ class TestDeleteUnusedDatasetsUsers:
             dataset=MasterDataSetFactory.create(user_access_type="REQUIRES_AUTHENTICATION")
         )
 
-        source_tables = source_tables_for_user(user)
+        source_tables_user_non_common, source_tables_user_common = source_tables_for_user(user)
         db_role_schema_suffix = db_role_schema_suffix_for_user(user)
         user_creds_to_drop = new_private_database_credentials(
             db_role_schema_suffix,
-            source_tables,
+            source_tables_user_non_common,
+            source_tables_user_common,
             postgres_user(user.email),
             user,
             valid_for=datetime.timedelta(days=31),
         )
         qs_creds_to_drop = new_private_database_credentials(
             db_role_schema_suffix,
-            source_tables,
+            source_tables_user_non_common,
+            source_tables_user_common,
             postgres_user(user.email, suffix="qs"),
             user,
             valid_for=datetime.timedelta(seconds=0),
         )
         qs_creds_to_keep = new_private_database_credentials(
             db_role_schema_suffix,
-            source_tables,
+            source_tables_user_non_common,
+            source_tables_user_common,
             postgres_user(user.email, suffix="qs"),
             user,
             valid_for=datetime.timedelta(minutes=1),


### PR DESCRIPTION
### Description of change

This PR introduces the concept of common and non-common tables to the functions that generate database credentials for users and applications. Common tables are those that every Data Workspace user has access to (Reference data and tables in catalogue pages without any access restrictions), non-common are the remainder (where access to the table is determined by a user's email domain name/being specifically granted access to tables on a catalogue page).

This is a step towards an implementation of the Data Workspace permissions model that doesn't require users to assume as many roles to query the data they have access to. This will have one role for all of the common tables, one for each of the email domains that are used to control access by domain, and one per catalogue page.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?