### PR TITLE
fix/change access level requirement for gitlab owners on visualisation approvals

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -1970,7 +1970,7 @@ def visualisation_approvals(dw_approvals, project_members):
                     if approver["is_superuser"] and member["access_level"] == 30
                     else (
                         "owner"
-                        if member["access_level"] == 40
+                        if member["access_level"] >= 40
                         else "peer reviewer" if member["access_level"] == 30 else None
                     )
                 )


### PR DESCRIPTION
Right now owners aren't coming through in the approvals process when they ought to be (Owner=50, Maintainer=40)