### PR TITLE
feat: separate out roles for tables granted by email domain

### DIFF
--- a/dataworkspace/dataworkspace/apps/accounts/management/commands/store_db_creds_in_s3.py
+++ b/dataworkspace/dataworkspace/apps/accounts/management/commands/store_db_creds_in_s3.py
@@ -26,13 +26,19 @@ class Command(BaseCommand):
         for user in all_users:
             self.stdout.write(f"Creating credentials for {user.email}")
 
-            source_tables_user_non_common, source_tables_user_common = source_tables_for_user(user)
+            (
+                source_tables_individual,
+                (user_email_domain, source_tables_email_domain),
+                source_tables_common,
+            ) = source_tables_for_user(user)
 
             db_role_schema_suffix = db_role_schema_suffix_for_user(user)
             creds = new_private_database_credentials(
                 db_role_schema_suffix,
-                source_tables_user_non_common,
-                source_tables_user_common,
+                source_tables_individual,
+                user_email_domain,
+                source_tables_email_domain,
+                source_tables_common,
                 postgres_user(user.email),
                 user,
                 valid_for=datetime.timedelta(days=31),

--- a/dataworkspace/dataworkspace/apps/api_v1/core/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/core/views.py
@@ -97,17 +97,21 @@ def get_superset_credentials(request):
         else:
             dashboards_user_can_access = []
 
-            source_tables_user_non_common, source_tables_user_common = source_tables_for_user(
-                dw_user
-            )
+            (
+                source_tables_individual,
+                (user_email_domain, source_tables_email_domain),
+                source_tables_common,
+            ) = source_tables_for_user(dw_user)
 
             db_role_schema_suffix = stable_identification_suffix(
                 str(dw_user.profile.sso_id), short=True
             )
             credentials = new_private_database_credentials(
                 db_role_schema_suffix,
-                source_tables_user_non_common,
-                source_tables_user_common,
+                source_tables_individual,
+                user_email_domain,
+                source_tables_email_domain,
+                source_tables_common,
                 postgres_user(dw_user.email, suffix="superset"),
                 dw_user,
                 valid_for=duration,

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -62,7 +62,15 @@ def spawn(
     user = get_user_model().objects.get(pk=user_id)
     application_instance = ApplicationInstance.objects.get(id=application_instance_id)
 
-    ((source_tables, source_tables_common), db_role_schema_suffix, db_user) = (
+    (
+        (
+            source_tables_individual,
+            (user_email_domain, source_tables_email_domain),
+            source_tables_common,
+        ),
+        db_role_schema_suffix,
+        db_user,
+    ) = (
         (
             source_tables_for_user(user),
             db_role_schema_suffix_for_user(user),
@@ -78,7 +86,9 @@ def spawn(
 
     credentials = new_private_database_credentials(
         db_role_schema_suffix,
-        source_tables,
+        source_tables_individual,
+        user_email_domain,
+        source_tables_email_domain,
         source_tables_common,
         db_user,
         user if application_instance.application_template.application_type == "TOOL" else None,

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -277,15 +277,27 @@ def application_api_is_allowed(request, public_host):
         ):
             raise ManageVisualisationsPermissionDeniedError()
 
-        source_tables_user_non_common, source_tables_user_common = source_tables_for_user(
-            request.user
+        (
+            user_source_tables_individual,
+            (_, user_source_tables_email_domain),
+            user_source_tables_common,
+        ) = source_tables_for_user(request.user)
+        user_source_tables = (
+            user_source_tables_individual
+            + user_source_tables_email_domain
+            + user_source_tables_common
         )
-        user_source_tables = source_tables_user_non_common + source_tables_user_common
 
-        source_tables_app_non_common, source_tables_app_common = source_tables_for_app(
-            application_template
+        (
+            app_source_tables_individual,
+            (_, app_source_tables_email_domain),
+            app_source_tables_common,
+        ) = source_tables_for_app(application_template)
+        app_source_tables = (
+            app_source_tables_individual
+            + app_source_tables_email_domain
+            + app_source_tables_common
         )
-        app_source_tables = source_tables_app_non_common + source_tables_app_common
 
         user_authorised_datasets = set(
             (source_table["dataset"]["id"] for source_table in user_source_tables)
@@ -938,9 +950,11 @@ def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_
                 # sure this is a case that can happen - and if it can, we don't care while prototyping.
                 logger.info("Syncing QuickSight resources for %s", dw_user)
 
-                source_tables_user_non_common, source_tables_user_common = source_tables_for_user(
-                    dw_user
-                )
+                (
+                    source_tables_individual,
+                    (user_email_domain, source_tables_email_domain),
+                    source_tables_common,
+                ) = source_tables_for_user(dw_user)
 
                 db_role_schema_suffix = stable_identification_suffix(str(sso_id), short=True)
 
@@ -950,8 +964,10 @@ def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_
                 # from expiring.
                 creds = new_private_database_credentials(
                     db_role_schema_suffix,
-                    source_tables_user_non_common,
-                    source_tables_user_common,
+                    source_tables_individual,
+                    user_email_domain,
+                    source_tables_email_domain,
+                    source_tables_common,
                     postgres_user(user_email, suffix="qs"),
                     dw_user,
                     valid_for=datetime.timedelta(

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -1434,13 +1434,22 @@ def _datasets(user, application_template):
     # to reverse the change, which may need urgent contact with support to
     # restore access
 
-    source_tables_user_non_common, source_tables_user_common = source_tables_for_user(user)
-    source_tables_user = source_tables_user_non_common + source_tables_user_common
-
-    source_tables_app_non_common, source_tables_app_common = source_tables_for_app(
-        application_template
+    (
+        source_tables_individual,
+        (_, source_tables_email_domain),
+        source_tables_common,
+    ) = source_tables_for_user(user)
+    source_tables_user = (
+        source_tables_individual + source_tables_email_domain + source_tables_common
     )
-    source_tables_app = source_tables_app_non_common + source_tables_app_common
+    (
+        source_tables_individual,
+        (_, source_tables_email_domain),
+        source_tables_common,
+    ) = source_tables_for_app(application_template)
+    source_tables_app = (
+        source_tables_individual + source_tables_email_domain + source_tables_common
+    )
 
     selectable_dataset_ids = set(
         source_table["dataset"]["id"]

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -152,7 +152,9 @@ def transaction_and_lock(cursor, lock_id):
 
 def new_private_database_credentials(
     db_role_and_schema_suffix,
-    source_tables,
+    source_tables_individual,
+    user_email_domain,
+    source_tables_email_domain,
     source_tables_common,
     db_user,
     dw_user: get_user_model(),
@@ -184,7 +186,9 @@ def new_private_database_credentials(
     def postgres_password():
         return "".join(secrets.choice(password_alphabet) for i in range(64))
 
-    def get_new_credentials(database_memorable_name, tables, tables_common):
+    def get_new_credentials(
+        database_memorable_name, tables_individual, tables_email_domain, tables_common
+    ):
         # Each real-world user is given
         # - a private and permanent schema where they can manage tables and rows as needed
         # - a permanent database role that is the owner of the schema
@@ -197,8 +201,12 @@ def new_private_database_credentials(
         database_data = settings.DATABASES_DATA[database_memorable_name]
         valid_until = datetime.datetime.now() + valid_for
 
-        schema_names = without_duplicates_preserve_order(
-            schema_name for schema_name, table_name in tables
+        schema_names_individual = without_duplicates_preserve_order(
+            schema_name for schema_name, table_name in tables_individual
+        )
+
+        schema_names_email_domain = without_duplicates_preserve_order(
+            schema_name for schema_name, table_name in tables_email_domain
         )
 
         schema_names_common = without_duplicates_preserve_order(
@@ -222,18 +230,40 @@ def new_private_database_credentials(
             sync_roles(
                 sync_roles_conn,
                 db_role,
-                grants=tuple(SchemaUsage(schema_name) for schema_name in schema_names)
-                + tuple(TableSelect(schema_name, table_name) for schema_name, table_name in tables)
+                grants=tuple(SchemaUsage(schema_name) for schema_name in schema_names_individual)
+                + tuple(
+                    TableSelect(schema_name, table_name)
+                    for schema_name, table_name in tables_individual
+                )
                 + tuple(RoleMembership(role_name) for role_name in db_shared_roles)
                 + (
                     RoleMembership("common"),
                     SchemaOwnership(db_role),
                     SchemaCreate(db_role),
                     SchemaUsage(db_role),
+                )
+                + (
+                    (RoleMembership("@" + user_email_domain),)
+                    if user_email_domain is not None
+                    else ()
                 ),
                 preserve_existing_grants_in_schemas=(db_role,),
                 lock_key=GLOBAL_LOCK_ID,
             )
+            if user_email_domain is not None:
+                sync_roles(
+                    sync_roles_conn,
+                    "@" + user_email_domain,
+                    grants=tuple(
+                        SchemaUsage(schema_name, direct=True)
+                        for schema_name in schema_names_email_domain
+                    )
+                    + tuple(
+                        TableSelect(schema_name, table_name, direct=True)
+                        for schema_name, table_name in tables_email_domain
+                    ),
+                    lock_key=GLOBAL_LOCK_ID,
+                )
             sync_roles(
                 sync_roles_conn,
                 "common",
@@ -328,13 +358,23 @@ def new_private_database_credentials(
             "db_password": db_password,
         }
 
-    database_to_tables = {
+    database_to_tables_individual = {
         database_memorable_name: [
             (source_table["schema"], source_table["table"])
             for source_table in source_tables_for_database
         ]
         for database_memorable_name, source_tables_for_database in itertools.groupby(
-            source_tables, lambda source_table: source_table["database"]
+            source_tables_individual, lambda source_table: source_table["database"]
+        )
+    }
+
+    database_to_tables_email_domain = {
+        database_memorable_name: [
+            (source_table["schema"], source_table["table"])
+            for source_table in source_tables_for_database
+        ]
+        for database_memorable_name, source_tables_for_database in itertools.groupby(
+            source_tables_email_domain, lambda source_table: source_table["database"]
         )
     }
 
@@ -352,17 +392,24 @@ def new_private_database_credentials(
     # access to tables in that database (e.g. for Data Explorer, where ensuring they can always connect to the database
     # can prevent a number of failure conditions.)
     for extra_db in force_create_for_databases:
-        if extra_db not in database_to_tables:
-            database_to_tables[extra_db] = []
+        if extra_db not in database_to_tables_individual:
+            database_to_tables_individual[extra_db] = []
+        if extra_db not in database_to_tables_email_domain:
+            database_to_tables_email_domain[extra_db] = []
         if extra_db not in database_to_tables_common:
             database_to_tables_common[extra_db] = []
 
-    database_names = set(database_to_tables.keys()) | set(database_to_tables_common.keys())
+    database_names = (
+        set(database_to_tables_individual.keys())
+        | set(database_to_tables_email_domain.keys())
+        | set(database_to_tables_common.keys())
+    )
 
     creds = [
         get_new_credentials(
             database_memorable_name,
-            database_to_tables.get(database_memorable_name, ()),
+            database_to_tables_individual.get(database_memorable_name, ()),
+            database_to_tables_email_domain.get(database_memorable_name, ()),
             database_to_tables_common.get(database_memorable_name, ()),
         )
         for database_memorable_name in database_names
@@ -533,11 +580,25 @@ def source_tables_for_user(user):
         "dataset__user_access_type",
     )
 
-    automatically_authorized_tables = SourceTable.objects.filter(
+    automatically_authorized_tables_published = SourceTable.objects.filter(
         dataset__deleted=False,
         dataset__authorized_email_domains__contains=[user_email_domain],
         published=True,
-        **{"dataset__published": True} if not user.is_superuser else {},
+        dataset__published=True,
+    ).values(
+        "database__memorable_name",
+        "schema",
+        "table",
+        "dataset__id",
+        "dataset__name",
+        "dataset__user_access_type",
+    )
+    automatically_authorized_tables_unpublished_if_superuser = SourceTable.objects.filter(
+        Q() if user.is_superuser else Q(pk__in=[]),
+        dataset__deleted=False,
+        dataset__authorized_email_domains__contains=[user_email_domain],
+        published=True,
+        dataset__published=False,
     ).values(
         "database__memorable_name",
         "schema",
@@ -560,7 +621,7 @@ def source_tables_for_user(user):
         .values("external_database__memorable_name", "table_name", "uuid", "name")
     )
 
-    source_tables_non_common = [
+    source_tables_individual = [
         {
             "database": x["database__memorable_name"],
             "schema": x["schema"],
@@ -572,7 +633,7 @@ def source_tables_for_user(user):
             },
         }
         for x in req_authorization_tables.union(
-            automatically_authorized_tables,
+            automatically_authorized_tables_unpublished_if_superuser,
             req_authentication_tables_unpublished_if_superuser,
         )
     ] + [
@@ -587,6 +648,20 @@ def source_tables_for_user(user):
             },
         }
         for x in reference_tables_unpublished_if_superuser
+    ]
+
+    source_tables_email_domain = [
+        {
+            "database": x["database__memorable_name"],
+            "schema": x["schema"],
+            "table": x["table"],
+            "dataset": {
+                "id": x["dataset__id"],
+                "name": x["dataset__name"],
+                "user_access_type": x["dataset__user_access_type"],
+            },
+        }
+        for x in automatically_authorized_tables_published
     ]
 
     source_tables_common = [
@@ -615,7 +690,11 @@ def source_tables_for_user(user):
         for x in req_authentication_tables_published
     ]
 
-    return (source_tables_non_common, source_tables_common)
+    return (
+        source_tables_individual,
+        (user_email_domain, source_tables_email_domain),
+        source_tables_common,
+    )
 
 
 def source_tables_for_app(application_template):
@@ -700,7 +779,7 @@ def source_tables_for_app(application_template):
         for x in req_authentication_tables
     ]
 
-    return (source_tables_non_common, source_tables_common)
+    return (source_tables_non_common, (None, []), source_tables_common)
 
 
 def view_exists(database, schema, view):

--- a/dataworkspace/dataworkspace/apps/explorer/utils.py
+++ b/dataworkspace/dataworkspace/apps/explorer/utils.py
@@ -179,9 +179,11 @@ def get_user_explorer_connection_settings(user, alias):
             if not user_credentials:
                 db_role_schema_suffix = db_role_schema_suffix_for_user(user)
 
-                source_tables_user_non_common, source_tables_user_common = source_tables_for_user(
-                    user
-                )
+                (
+                    source_tables_individual,
+                    (user_email_domain, source_tables_email_domain),
+                    source_tables_common,
+                ) = source_tables_for_user(user)
 
                 db_user = postgres_user(user.email, suffix="explorer")
                 duration = timedelta(hours=24)
@@ -189,8 +191,10 @@ def get_user_explorer_connection_settings(user, alias):
 
                 user_credentials = new_private_database_credentials(
                     db_role_schema_suffix,
-                    source_tables_user_non_common,
-                    source_tables_user_common,
+                    source_tables_individual,
+                    user_email_domain,
+                    source_tables_email_domain,
+                    source_tables_common,
                     db_user,
                     user,
                     valid_for=duration,

--- a/dataworkspace/dataworkspace/tests/api_v1/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/core/test_views.py
@@ -36,7 +36,7 @@ class TestGetSupersetCredentialsAPIView:
         ]
         mock_new_credentials.return_value = credentials
 
-        mock_source_tables.return_value = ([], [])
+        mock_source_tables.return_value = ([], ("@dummy.test", []), [])
 
         user = factories.UserFactory()
         tools_permission = Permission.objects.get(

--- a/dataworkspace/dataworkspace/tests/core/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/core/test_utils.py
@@ -108,12 +108,18 @@ class TestPostgresUser:
         user_count = DatabaseUser.objects.count()
 
         user = factories.UserFactory()
-        source_tables_user_non_common, source_tables_user_common = source_tables_for_user(user)
+        (
+            source_tables_individual,
+            (user_email_domain, source_tables_email_domain),
+            source_tables_common,
+        ) = source_tables_for_user(user)
         db_role_schema_suffix = db_role_schema_suffix_for_user(user)
         new_private_database_credentials(
             db_role_schema_suffix,
-            source_tables_user_non_common,
-            source_tables_user_common,
+            source_tables_individual,
+            user_email_domain,
+            source_tables_email_domain,
+            source_tables_common,
             user.email,
             user,
             valid_for=datetime.timedelta(days=31),
@@ -134,12 +140,18 @@ class TestNewPrivateDatabaseCredentials:
             )
         )
 
-        source_tables_user_non_common, source_tables_user_common = source_tables_for_user(user)
+        (
+            source_tables_individual,
+            (user_email_domain, source_tables_email_domain),
+            source_tables_common,
+        ) = source_tables_for_user(user)
         db_role_schema_suffix = db_role_schema_suffix_for_user(user)
         user_creds_to_drop = new_private_database_credentials(
             db_role_schema_suffix,
-            source_tables_user_non_common,
-            source_tables_user_common,
+            source_tables_individual,
+            user_email_domain,
+            source_tables_email_domain,
+            source_tables_common,
             postgres_user(user.email),
             user,
             valid_for=datetime.timedelta(days=1),
@@ -167,28 +179,38 @@ class TestDeleteUnusedDatasetsUsers:
             dataset=MasterDataSetFactory.create(user_access_type="REQUIRES_AUTHENTICATION")
         )
 
-        source_tables_user_non_common, source_tables_user_common = source_tables_for_user(user)
+        (
+            source_tables_individual,
+            (user_email_domain, source_tables_email_domain),
+            source_tables_common,
+        ) = source_tables_for_user(user)
         db_role_schema_suffix = db_role_schema_suffix_for_user(user)
         user_creds_to_drop = new_private_database_credentials(
             db_role_schema_suffix,
-            source_tables_user_non_common,
-            source_tables_user_common,
+            source_tables_individual,
+            user_email_domain,
+            source_tables_email_domain,
+            source_tables_common,
             postgres_user(user.email),
             user,
             valid_for=datetime.timedelta(days=31),
         )
         qs_creds_to_drop = new_private_database_credentials(
             db_role_schema_suffix,
-            source_tables_user_non_common,
-            source_tables_user_common,
+            source_tables_individual,
+            user_email_domain,
+            source_tables_email_domain,
+            source_tables_common,
             postgres_user(user.email, suffix="qs"),
             user,
             valid_for=datetime.timedelta(seconds=0),
         )
         qs_creds_to_keep = new_private_database_credentials(
             db_role_schema_suffix,
-            source_tables_user_non_common,
-            source_tables_user_common,
+            source_tables_individual,
+            user_email_domain,
+            source_tables_email_domain,
+            source_tables_common,
             postgres_user(user.email, suffix="qs"),
             user,
             valid_for=datetime.timedelta(minutes=1),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -373,7 +373,7 @@ pep517==0.10.0
     # via pip-tools
 pexpect==4.8.0
     # via ipython
-pg-sync-roles==0.0.41
+pg-sync-roles==0.0.42
     # via -r requirements.txt
 pglast==3.18
     # via -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -204,7 +204,7 @@ packaging==22.0
     # via bleach
 paste==3.4.3
     # via -r requirements.in
-pg-sync-roles==0.0.41
+pg-sync-roles==0.0.42
     # via -r requirements.in
 pglast==3.18
     # via -r requirements.in


### PR DESCRIPTION
### Description of change

This changes how database table privileges are granted for users that get access by their email domain. Instead of being granted a per-table role, there is now a per-email-domain role.

This is done to try to limit the number of role memberships users have, which causes performance problems on connection.

This includes a bump to pg-sync-roles that fixes a bug where it doesn't grant permissions when it should.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?