### PR TITLE
build(deps): bump pg-sync-roles

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -373,7 +373,7 @@ pep517==0.10.0
     # via pip-tools
 pexpect==4.8.0
     # via ipython
-pg-sync-roles==0.0.42
+pg-sync-roles==0.0.43
     # via -r requirements.txt
 pglast==3.18
     # via -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -204,7 +204,7 @@ packaging==22.0
     # via bleach
 paste==3.4.3
     # via -r requirements.in
-pg-sync-roles==0.0.42
+pg-sync-roles==0.0.43
     # via -r requirements.in
 pglast==3.18
     # via -r requirements.in


### PR DESCRIPTION
### Description of change

This bumps the version of pg-sync-roles.

This is to have https://github.com/uktrade/pg-sync-roles/pull/133 to reduce a bit of churn on the database. In a future change we're about to call sync_roles much more (once per dataset), so I think good to get this in before.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?