### PR TITLE
create direct role for user and team schemas

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -257,7 +257,7 @@ def new_private_database_credentials(
                     RoleMembership("common"),
                     SchemaOwnership(db_role),
                     SchemaCreate(db_role),
-                    SchemaUsage(db_role),
+                    SchemaUsage(db_role, direct=True),
                 )
                 + (
                     (RoleMembership("@" + user_email_domain),)
@@ -309,7 +309,7 @@ def new_private_database_credentials(
                     grants=(
                         SchemaOwnership(db_team_role),
                         SchemaCreate(db_team_role),
-                        SchemaUsage(db_team_role),
+                        SchemaUsage(db_team_role, direct=True),
                     ),
                     preserve_existing_grants_in_schemas=(db_team_role,),
                     lock_key=GLOBAL_LOCK_ID,


### PR DESCRIPTION
### Description of change
Setting direct=true on schema usage for both private and team schemas, permissions are granted for the role directly instead of using intermediary role.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?