### PR TITLE
perf: use direct mode for schema create permission

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -256,7 +256,7 @@ def new_private_database_credentials(
                 + (
                     RoleMembership("common"),
                     SchemaOwnership(db_role),
-                    SchemaCreate(db_role),
+                    SchemaCreate(db_role, direct=True),
                     SchemaUsage(db_role, direct=True),
                 )
                 + (
@@ -308,7 +308,7 @@ def new_private_database_credentials(
                     db_team_role,
                     grants=(
                         SchemaOwnership(db_team_role),
-                        SchemaCreate(db_team_role),
+                        SchemaCreate(db_team_role, direct=True),
                         SchemaUsage(db_team_role, direct=True),
                     ),
                     preserve_existing_grants_in_schemas=(db_team_role,),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -376,7 +376,7 @@ pep517==0.10.0
     # via pip-tools
 pexpect==4.8.0
     # via ipython
-pg-sync-roles==0.0.43
+pg-sync-roles==0.0.44
     # via -r requirements.txt
 pglast==3.18
     # via -r /Users/jamesrobinson/work/data-workspace-frontend/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -209,7 +209,7 @@ packaging==22.0
     # via bleach
 paste==3.4.3
     # via -r requirements.in
-pg-sync-roles==0.0.43
+pg-sync-roles==0.0.44
     # via -r requirements.in
 pglast==3.18
     # via -r requirements.in


### PR DESCRIPTION
### Description of change

To try to reduce the time to connection to the datasets db, we're reducing the number of rules the connecting user has.

This change uses direct=True mode on the schema create permission to avoid using the intermediate role on schemas that users have the ability to create tables in: private and team schemas.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?