### PR TITLE
fix: missing schema usage for email-domain granted datasets

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -272,6 +272,10 @@ def new_private_database_credentials(
                     sync_roles_conn,
                     "@" + user_email_domain,
                     grants=tuple(
+                        SchemaUsage(schema_name, direct=True)
+                        for schema_name in schema_names_email_domain
+                    )
+                    + tuple(
                         TableSelect(schema_name, table_name, direct=True)
                         for dataset_id, schema_name, table_name in tables_email_domain
                     ),


### PR DESCRIPTION
### Description of change

A previous optimisation incorrectly removed the schema USAGE permission for email-domain-granted datasets. This adds that back in.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?