### PR TITLE
fix/reinstate check on maintainer access level

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/gitlab.py
+++ b/dataworkspace/dataworkspace/apps/applications/gitlab.py
@@ -153,7 +153,7 @@ def gitlab_has_developer_access(user, gitlab_project_id: int) -> bool:
 
 def is_project_owner(user, gitlab_project_id: int) -> bool:
     current_gitlab_project_user = gitlab_project_member_by_id(user, gitlab_project_id)
-    return bool(current_gitlab_project_user["access_level"] == MAINTAINER_ACCESS_LEVEL)
+    return bool(current_gitlab_project_user["access_level"] >= MAINTAINER_ACCESS_LEVEL)
 
 
 def is_dataworkspace_team_member(user, gitlab_project_id) -> bool:

--- a/dataworkspace/dataworkspace/tests/applications/test_gitlab.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_gitlab.py
@@ -136,5 +136,5 @@ class TestGitlabIsProjectOwner:
         assert is_project_owner({"id": 1}, "1") is True
 
     def test_user_is_not_project_owner(self, gitlab_mock):
-        gitlab_mock.return_value = [{"access_level": 41}]
+        gitlab_mock.return_value = [{"access_level": 39}]
         assert is_project_owner({"id": 1}, "1") is False

--- a/dataworkspace/dataworkspace/tests/applications/test_visualisation_owner_ui_approval.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_visualisation_owner_ui_approval.py
@@ -22,7 +22,7 @@ from dataworkspace.tests.common import get_http_sso_data
 @contextmanager
 def _visualisation_ui_gitlab_mocks(
     owner_access=True,
-    access_level=40,
+    access_level=50,
     project_members=None,
     user=None,
 ):
@@ -97,7 +97,7 @@ class TestDataVisualisationOwnerUIApprovalPage:
                     "name": "Ledia Luli",
                     "username": "ledia.luli",
                     "state": "active",
-                    "access_level": 40,
+                    "access_level": 50,
                 }
             ]
         ):
@@ -266,7 +266,7 @@ class TestDataVisualisationOwnerUIApprovalPage:
                     "name": "Ledia Luli",
                     "username": "ledia.luli",
                     "state": "active",
-                    "access_level": 40,
+                    "access_level": 45,
                 }
             ],
         ):


### PR DESCRIPTION
Regression on the equality check on Owner access means that Maintainers are not being evaluated as owners. Have changed some of the access levels we're testing in the tests to make sure that gitlab_access level >= 40 is still being treated as an owner.