### PR TITLE
refactor: ConfirmDialog

### DIFF
--- a/cypress/e2e/data-catalogue/unpublish-data-catalogue.cy.ts
+++ b/cypress/e2e/data-catalogue/unpublish-data-catalogue.cy.ts
@@ -45,7 +45,7 @@ describe('Unpublish catalogue page', () => {
     cy.getOpenDialog().within(() => {
       cy.contains('strong', 'Final review before unpublishing').should('exist');
       cy.contains(
-        "By clicking the 'Yes' button below you're confirmimg:"
+        "By clicking the 'Yes' button below you're confirming:"
       ).should('exist');
       cy.contains(
         'this catalogue page needs to be unpublished because of a potential data breach'

--- a/dataworkspace/dataworkspace/static/js/react/components/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/components/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -56,16 +56,12 @@ export const ConfirmCustomBody: Story = {
         </StyledParagraph>
         <UnorderedList>
           <ListItem>
-            <Paragraph>
-              this catalogue page needs to be unpublished because of a potential
-              data breach
-            </Paragraph>
+            this catalogue page needs to be unpublished because of a potential
+            data breach
           </ListItem>
           <ListItem>
-            <Paragraph>
-              you understand that any data linked to this catalogue page will
-              also be removed
-            </Paragraph>
+            you understand that any data linked to this catalogue page will also
+            be removed
           </ListItem>
         </UnorderedList>
       </>

--- a/dataworkspace/dataworkspace/static/js/react/components/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/components/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -2,7 +2,10 @@
 import React from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react';
+import { ListItem, Paragraph, UnorderedList } from 'govuk-react';
+import styled from 'styled-components';
 
+import { ERROR_COLOUR } from '../../constants';
 import { ConfirmDialog } from './index';
 
 const meta = {
@@ -11,6 +14,10 @@ const meta = {
 } satisfies Meta<typeof ConfirmDialog>;
 
 type Story = StoryObj<typeof ConfirmDialog>;
+
+const StyledParagraph = styled(Paragraph)`
+  padding-top: 30px;
+`;
 
 export const ConfirmRemoveUser: Story = {
   render: () => (
@@ -26,6 +33,43 @@ export const ConfirmRemoveUser: Story = {
       title="Are you sure you want to remove Jones?"
       warning={false}
     />
+  )
+};
+
+export const ConfirmCustomBody: Story = {
+  render: () => (
+    <ConfirmDialog
+      actionUrl="/submit-team"
+      buttonValueAccept='""'
+      buttonTextAccept="Yes"
+      buttonTextCancel="Cancel"
+      buttonColourAccept={ERROR_COLOUR}
+      csrf_token="456"
+      onClose={() => {}}
+      open={true}
+      title="Are you sure you want to unpublish the catalogue"
+      warning={true}
+    >
+      <>
+        <StyledParagraph>
+          By clicking the 'Yes' button below you're confirming:
+        </StyledParagraph>
+        <UnorderedList>
+          <ListItem>
+            <Paragraph>
+              this catalogue page needs to be unpublished because of a potential
+              data breach
+            </Paragraph>
+          </ListItem>
+          <ListItem>
+            <Paragraph>
+              you understand that any data linked to this catalogue page will
+              also be removed
+            </Paragraph>
+          </ListItem>
+        </UnorderedList>
+      </>
+    </ConfirmDialog>
   )
 };
 

--- a/dataworkspace/dataworkspace/static/js/react/components/ConfirmDialog/index.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/components/ConfirmDialog/index.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 type ConfirmDialogProps = {
   actionUrl: string;
   bodyText?: string;
-  bodyElement?: React.ReactNode;
+  children?: React.ReactNode;
   buttonTextAccept: string;
   buttonColourAccept?: string;
   buttonTextCancel: string;
@@ -66,16 +66,16 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = (props) => {
       ref={refModal}
       warning={props.warning}
     >
-      {props.warning === false ? (
-        <H2 size="LARGE">{props.title}</H2>
-      ) : (
+      {props.warning ? (
         <StyledWarning>{props.title}</StyledWarning>
+      ) : (
+        <H2 size="LARGE">{props.title}</H2>
       )}
       {props.bodyText && props.bodyText.length > 0 && (
         <StyledParagraph>{props.bodyText}</StyledParagraph>
       )}
 
-      {props.bodyElement}
+      {props.children}
 
       <ContainerButtonGroup>
         <StyledForm

--- a/dataworkspace/dataworkspace/static/js/react/features/unpublish-catalogue-page/UnpublishCataloguePage.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/unpublish-catalogue-page/UnpublishCataloguePage.tsx
@@ -60,16 +60,12 @@ const UnpublishCataloguePage = ({
             </StyledParagraph>
             <UnorderedList>
               <ListItem>
-                <Paragraph>
-                  this catalogue page needs to be unpublished because of a
-                  potential data breach
-                </Paragraph>
+                this catalogue page needs to be unpublished because of a
+                potential data breach
               </ListItem>
               <ListItem>
-                <Paragraph>
-                  you understand that any data linked to this catalogue page
-                  will also be removed
-                </Paragraph>
+                you understand that any data linked to this catalogue page will
+                also be removed
               </ListItem>
             </UnorderedList>
           </>

--- a/dataworkspace/dataworkspace/static/js/react/features/unpublish-catalogue-page/UnpublishCataloguePage.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/unpublish-catalogue-page/UnpublishCataloguePage.tsx
@@ -44,27 +44,6 @@ const UnpublishCataloguePage = ({
       {isOpen && (
         <ConfirmDialog
           actionUrl={data.unpublish_url}
-          bodyElement={
-            <>
-              <StyledParagraph>
-                By clicking the 'Yes' button below you're confirmimg:
-              </StyledParagraph>
-              <UnorderedList>
-                <ListItem>
-                  <Paragraph>
-                    this catalogue page needs to be unpublished because of a
-                    potential data breach
-                  </Paragraph>
-                </ListItem>
-                <ListItem>
-                  <Paragraph>
-                    you understand that any data linked to this catalogue page
-                    will also be removed
-                  </Paragraph>
-                </ListItem>
-              </UnorderedList>
-            </>
-          }
           csrf_token={csrf_token}
           title="Final review before unpublishing"
           open={isOpen}
@@ -74,7 +53,27 @@ const UnpublishCataloguePage = ({
           buttonTextCancel={'Close'}
           buttonValueAccept="unpublish-catalogue"
           warning={true}
-        ></ConfirmDialog>
+        >
+          <>
+            <StyledParagraph>
+              By clicking the 'Yes' button below you're confirmimg:
+            </StyledParagraph>
+            <UnorderedList>
+              <ListItem>
+                <Paragraph>
+                  this catalogue page needs to be unpublished because of a
+                  potential data breach
+                </Paragraph>
+              </ListItem>
+              <ListItem>
+                <Paragraph>
+                  you understand that any data linked to this catalogue page
+                  will also be removed
+                </Paragraph>
+              </ListItem>
+            </UnorderedList>
+          </>
+        </ConfirmDialog>
       )}
     </>
   );

--- a/dataworkspace/dataworkspace/static/js/react/features/unpublish-catalogue-page/UnpublishCataloguePage.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/features/unpublish-catalogue-page/UnpublishCataloguePage.tsx
@@ -56,7 +56,7 @@ const UnpublishCataloguePage = ({
         >
           <>
             <StyledParagraph>
-              By clicking the 'Yes' button below you're confirmimg:
+              By clicking the 'Yes' button below you're confirming:
             </StyledParagraph>
             <UnorderedList>
               <ListItem>


### PR DESCRIPTION
### Description of change

- Refactored `ConfirmDialog/index.tsx` to remove the `bodyElement` prop (my bad) in favour of using `children`, aligning with React best practices and improving consistency
- Added a new story to demonstrate the updated usage with `children`.
- Removed excess space around dialog list items.
- Corrected a typo.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?