### PR TITLE
feat: new WarningText component

### DIFF
--- a/dataworkspace/dataworkspace/static/js/eslint.config.mjs
+++ b/dataworkspace/dataworkspace/static/js/eslint.config.mjs
@@ -83,7 +83,20 @@ export default [
           groups: [['^react'], ['^antd'], ['^@?\\w'], ['@/(.*)'], ['^[./]']]
         }
       ],
-      '@typescript-eslint/ban-ts-comment': 'off'
+      '@typescript-eslint/ban-ts-comment': 'off',
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'govuk-react',
+              importNames: ['WarningText'],
+              message:
+                "Do not import 'WarningText' from 'govuk-react'. Use '../components/WarningText' instead."
+            }
+          ]
+        }
+      ]
     }
   },
   {

--- a/dataworkspace/dataworkspace/static/js/react/components/ConfirmDialog/index.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/components/ConfirmDialog/index.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef } from 'react';
 
 import { SPACING_POINTS } from '@govuk-react/constants';
-import { Button, H2, Link, Paragraph, WarningText } from 'govuk-react';
+import { Button, H2, Link, Paragraph } from 'govuk-react';
 import styled from 'styled-components';
+
+import WarningText from '../WarningText';
 
 type ConfirmDialogProps = {
   actionUrl: string;

--- a/dataworkspace/dataworkspace/static/js/react/components/WarningText/IconImportant.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/components/WarningText/IconImportant.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+type Props = {
+  fill?: string;
+};
+
+const IconImportant: React.FC<Props> = ({ fill = 'black', ...rest }: Props) => (
+  <svg
+    viewBox="0 0 100 100"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...rest}
+  >
+    {/* Outer circle */}
+    <circle cx="50" cy="50" r="50" fill={fill} />
+
+    {/* Exclamation mark stem */}
+    <path d="M42 20 L55 20 L55 60 L44 60 Z" fill="white" />
+
+    {/* Dot */}
+    <circle cx="50" cy="76" r="9" fill="white" />
+  </svg>
+);
+
+export default IconImportant;

--- a/dataworkspace/dataworkspace/static/js/react/components/WarningText/index.tsx
+++ b/dataworkspace/dataworkspace/static/js/react/components/WarningText/index.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+import { SPACING_POINTS } from '@govuk-react/constants';
+import { typography } from '@govuk-react/lib';
+import styled from 'styled-components';
+
+import IconImportant from './IconImportant';
+
+const StyledWarningText = styled('div')({
+  alignItems: 'center',
+  boxSizing: 'border-box',
+  display: 'flex',
+  width: '100%'
+});
+
+const IconImportantWrapper = styled('div')({
+  flex: 'none',
+  width: 35,
+  height: 35,
+  marginRight: SPACING_POINTS[3]
+});
+
+const WarningTextWrapper = styled('strong')(
+  typography.font({ size: 19, weight: 'bold' })
+);
+
+export const WarningText: React.FC<WarningTextProps> = ({
+  children,
+  ...props
+}: WarningTextProps) => (
+  <StyledWarningText {...props}>
+    <IconImportantWrapper>
+      <IconImportant />
+    </IconImportantWrapper>
+    <WarningTextWrapper>{children}</WarningTextWrapper>
+  </StyledWarningText>
+);
+
+WarningText.displayName = 'WarningText';
+
+export interface WarningTextProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export default WarningText;


### PR DESCRIPTION
### Description of change


New `WarningText` component that improves the wonky icon from `govuk-react`

<img width="736" alt="Screenshot 2025-04-15 at 11 33 12" src="https://github.com/user-attachments/assets/c6457a4b-9968-4ddf-b75e-c6b7f8fc2fa4" />

---
When text wraps the icon stays central

<img width="611" alt="Screenshot 2025-04-15 at 11 43 37" src="https://github.com/user-attachments/assets/71c3504f-3d19-4aee-9044-b8441e750340" />

---
[Current WarningText component](https://govuk-react.github.io/govuk-react/?path=/docs/warning-text--docs)
<img width="611" alt="Screenshot 2025-04-15 at 11 47 26" src="https://github.com/user-attachments/assets/ffcb10b0-07d4-4554-bad2-6b1c0ce8043e" />

---
Now, if someone writes:

```js
import { WarningText } from govuk-react
```

They'll get an ESLint error with a custom message.

```sh
error  'WarningText' import from 'govuk-react' is restricted. Do not import 'WarningText' from 'govuk-react'. Use '../components/WarningText' instead  no-restricted-imports
```

Correct usage:

```js
import WarningText from 'path/to/components/WarningText'
```

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?