### PR TITLE
Fix/security: remove Server header from healthcheck response

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/views.py
+++ b/dataworkspace/dataworkspace/apps/core/views.py
@@ -178,7 +178,9 @@ def healthcheck_view(request):
     if request.method != "GET":
         return HttpResponseNotAllowed(["GET"])
     if check_db("default"):
-        return HttpResponse("OK")
+        respone = HttpResponse("OK")
+        response["Server"] = ""
+        return response
     return HttpResponseServerError("Database not available")
 
 
@@ -218,7 +220,7 @@ class SupportView(FormView):
         if support_Type == form.SupportTypes.NEW_DATASET:
             if waffle.flag_is_active(request, settings.REQUESTING_DATA):
                 return HttpResponseRedirect(
-                    reverse("requesting-data-summary-information-step", args={("name")})
+                    reverse("requesting-data-summary-information-step", args={"name"})
                 )
             return HttpResponseRedirect(
                 f'{reverse("add-dataset-request")}?email={cleaned["email"]}'

--- a/dataworkspace/dataworkspace/apps/core/views.py
+++ b/dataworkspace/dataworkspace/apps/core/views.py
@@ -178,7 +178,7 @@ def healthcheck_view(request):
     if request.method != "GET":
         return HttpResponseNotAllowed(["GET"])
     if check_db("default"):
-        respone = HttpResponse("OK")
+        response = HttpResponse("OK")
         response["Server"] = ""
         return response
     return HttpResponseServerError("Database not available")

--- a/dataworkspace/dataworkspace/tests/request_access/test_requesting_data_integration.py
+++ b/dataworkspace/dataworkspace/tests/request_access/test_requesting_data_integration.py
@@ -18,7 +18,7 @@ class TestRequestingData(TestCase):
         self.client = Client(**get_http_sso_data(self.user))
 
     def assert_common_content_one_label_page(self, stage, url_name, label):
-        response = self.client.get(reverse(f"requesting-data-{stage}-step", args={(url_name)}))
+        response = self.client.get(reverse(f"requesting-data-{stage}-step", args={url_name}))
 
         soup = BeautifulSoup(response.content.decode(response.charset))
         header = soup.find("h1").contents[0]
@@ -29,7 +29,7 @@ class TestRequestingData(TestCase):
         assert label in input_label
 
     def assert_common_content_radio_buttons_page(self, stage, url_name, label, radio_options):
-        response = self.client.get(reverse(f"requesting-data-{stage}-step", args={(url_name)}))
+        response = self.client.get(reverse(f"requesting-data-{stage}-step", args={url_name}))
 
         soup = BeautifulSoup(response.content.decode(response.charset))
         header = soup.find("h1").contents[0]
@@ -45,7 +45,7 @@ class TestRequestingData(TestCase):
             assert option.lower() in radio_names
 
     def assert_common_content_user_search_page(self, stage, url_name, label, hint):
-        response = self.client.get(reverse(f"requesting-data-{stage}-step", args={(url_name)}))
+        response = self.client.get(reverse(f"requesting-data-{stage}-step", args={url_name}))
 
         soup = BeautifulSoup(response.content.decode(response.charset))
         header = soup.find("h1").contents[0]
@@ -64,7 +64,7 @@ class TestRequestingData(TestCase):
 
     def test_descriptions_page(self):
         response = self.client.get(
-            reverse("requesting-data-summary-information-step", args={("descriptions")})
+            reverse("requesting-data-summary-information-step", args={"descriptions"})
         )
 
         soup = BeautifulSoup(response.content.decode(response.charset))

--- a/healthcheck/healthcheck.py
+++ b/healthcheck/healthcheck.py
@@ -12,7 +12,7 @@ async def async_main(port, url):
         async with aiohttp.ClientSession() as client_session:
             async with client_session.get(url) as response:
                 response = await response.text()
-                return web.Response(text=response)
+                return web.Response(text=response, headers={"Server": ""})
 
     async def handle_healthcheck_alb(_):
         return web.Response(text="OK")

--- a/healthcheck/healthcheck.py
+++ b/healthcheck/healthcheck.py
@@ -15,7 +15,7 @@ async def async_main(port, url):
                 return web.Response(text=response, headers={"Server": ""})
 
     async def handle_healthcheck_alb(_):
-        return web.Response(text="OK")
+        return web.Response(text="OK", headers={"Server": ""})
 
     app = web.Application()
     app.add_routes(


### PR DESCRIPTION
PEN test identified that too much information about the server is being returned in the healthcheck response header.