### PR TITLE
infra: bump PostgreSQL to 13.18

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,6 +1,6 @@
-FROM postgres:12.9
+FROM postgres:13.18
 
-RUN apt-get update && apt-get install -y --no-install-recommends postgresql-12-pgaudit
+RUN apt-get update && apt-get install -y --no-install-recommends postgresql-13-pgaudit
 
 COPY /entrypoint.sh /
 COPY /1-init-libraries.sh /docker-entrypoint-initdb.d/


### PR DESCRIPTION
### Description of change

This increases the version of PostgreSQL when running locally and in tests to 13.18 (this is not the latest version 13.20, because at the time of writing non-Aurora RDS seems to only allow upgrade to 13.18)

This is in advance of increasing the version when deployed to match.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?