### PR TITLE
fix to only add active user on collection when invited by user

### DIFF
--- a/dataworkspace/dataworkspace/apps/data_collections/views.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/views.py
@@ -388,7 +388,7 @@ class CollectionUsersView(FormView):
             with transaction.atomic():
                 membership = CollectionUserMembership.objects.create(
                     collection=collection,
-                    user=get_user_model().objects.get(email=form.cleaned_data["email"]),
+                    user=get_user_model().objects.get(email=form.cleaned_data["email"], is_active=True),
                     created_by=self.request.user,
                 )
                 log_event(

--- a/dataworkspace/dataworkspace/apps/data_collections/views.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/views.py
@@ -388,7 +388,9 @@ class CollectionUsersView(FormView):
             with transaction.atomic():
                 membership = CollectionUserMembership.objects.create(
                     collection=collection,
-                    user=get_user_model().objects.get(email=form.cleaned_data["email"], is_active=True),
+                    user=get_user_model().objects.get(
+                        email=form.cleaned_data["email"], is_active=True
+                    ),
                     created_by=self.request.user,
                 )
                 log_event(


### PR DESCRIPTION
### Description of change
The PR fix the error surfaced when a data workspace user (Email address) have a duplicate sso ID with active and non-active status on Collection. When Data workspace user invite another user to collection, only active user is fetched.
[`Link to the ticket on Jira`](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-2699)

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?