### PR TITLE
build(deps): avoid installing unpinned pip, wheel, and pip-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,7 @@ COPY requirements.txt requirements.txt
 COPY etc /etc
 COPY dataworkspace /dataworkspace
 
-RUN python3 -m pip install --upgrade pip wheel pip-tools && \
-    python3 -m pip install -r requirements.txt
+RUN python3 -m pip install -r requirements.txt
 
 # Leave this statement at the end, as it is dependant on the builder layer completing. Having this
 # COPY statement will block this layer building, so placing at the end will let the installs above finish


### PR DESCRIPTION
### Description of change

This avoids installing unpinned versions of pip, wheel, and pip-tools, where they are already installed elsewhere in the Dockerfile, either via requirements file or by installing them as Debian packages.

This is to address the error when building the test layer in the Dockerfile, e.g. from `docker build . --target test`:

> 13.33 ERROR: Exception:
> 13.33 Traceback (most recent call last):
> 13.33   File "/usr/lib/python3.9/py_compile.py", line 144, in compile
> 13.33     code = loader.source_to_code(source_bytes, dfile or file,
> 13.33   File "<frozen importlib._bootstrap_external>", line 853, in source_to_code
> 13.33   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
> 13.33   File "/usr/local/lib/python3.9/dist-packages/../../../pydevd_attach_to_process/winappdbg/plugins/do_example.py", line 37
> 13.33     print "This is an example command."
> 13.33           ^
> 13.33 SyntaxError: Missing parentheses in call to 'print'. Did you mean print("This is an example command.")?

Although the exact reason why this change fixes the issue isn't known, it's suspected to be related to the fact that in the past few days there have been releases of both setuptools and pip. There is an issue raised with pip, https://github.com/pypa/pip/issues/13359, that has a similar but not identical error, and relates it to the recent release of pip 25.1, so that I think is the most likely cause.

It was initially suspected that the issue was due to the recent PostgreSQL upgrade in https://github.com/uktrade/data-workspace-frontend/pull/3560, but since the changes were in another Docker container unrelated to Python, that is now suspected to be unlikely.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?