### PR TITLE
feat: open up /pipelines to all users, but have it empty unless superuser

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
+++ b/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
@@ -17,12 +17,14 @@
         <div class="govuk-grid-column-full">
             <h1 class="govuk-heading-xl">Pipelines</h1>
             <dl class="govuk-summary-list">
+                {% if can_add_pipeline %}
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__value">
                     <a class="govuk-link" href="{% url 'pipelines:create' %}">Add new pipeline</a>
                     </dt>
                     <dd class="govuk-summary-list__actions"></dd>
                 </div>
+                {% endif %}
                 {% for object in object_list %}
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__value">
@@ -71,6 +73,13 @@
                         {{ object.type }}
                       </strong>
                     </dd>
+                </div>
+                {% empty %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__value">
+                      You do not have access to any pipelines.
+                    </dt>
+                    <dd class="govuk-summary-list__actions"></dd>
                 </div>
                 {% endfor %}
             </dl>

--- a/dataworkspace/dataworkspace/tests/core/test_error_pages.py
+++ b/dataworkspace/dataworkspace/tests/core/test_error_pages.py
@@ -169,16 +169,6 @@ def test_other_users_query_results(user):
 
 
 @pytest.mark.django_db
-def test_non_admin_pipeline_access(user):
-    client = Client(raise_request_exception=False, **get_http_sso_data(user))
-    response = client.get(reverse("pipelines:index"))
-    assert response.status_code == 403
-    assert "You do not have permission to access the Pipeline builder" in response.content.decode(
-        response.charset
-    )
-
-
-@pytest.mark.django_db
 def test_visualisations_permission_denied(user):
     client = Client(raise_request_exception=False, **get_http_sso_data(user))
     response = client.get(reverse("visualisations:root"))


### PR DESCRIPTION
### Description of change

This opens up the /pipeline page to all users, but unless the user is a superuser, just have it show a message that the user has no access to any pipelines.

This isn't particularly useful itself - the main reason for this is that this is a stepping stone in terms of code and UX to a bigger feature where Data Catalogue Editors, IAMs, and IAOs can trigger pipelines for datasets they manage.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?