### PR TITLE
feat: catalogue editors can start and stop own Sharepoint pipelines

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
@@ -26,10 +26,34 @@ from dataworkspace.apps.explorer.schema import get_user_schema_info
 logger = logging.getLogger("app")
 
 
+def filter_user_pipelines(user, pipelines_qs):
+    if not user.is_superuser:
+        # Find all the table names that the user is catalogue editor for...
+        source_datasets = user.data_catalogue_edit_datasets.all()
+        source_tables = SourceTable.objects.filter(dataset__in=source_datasets)
+        # and filter for pipelines that populate those tables
+        pipeline_table_names = [
+            f"{source_table.schema}.{source_table.table}" for source_table in source_tables
+        ]
+        pipelines_qs = pipelines_qs.filter(table_name__in=pipeline_table_names, type="sharepoint")
+
+    return pipelines_qs
+
+
 class IsAdminMixin(UserPassesTestMixin):
     def test_func(self):
         if not self.request.user.is_superuser:
             raise PipelineBuilderPermissionDeniedError()
+        return True
+
+
+class IsAdminOrEditorMixin(UserPassesTestMixin):
+    def test_func(self):
+        pipelines_qs = Pipeline.objects.filter(id=self.kwargs["pk"])
+        user_pipelines = filter_user_pipelines(self.request.user, pipelines_qs)
+        if not user_pipelines.exists():
+            raise PipelineBuilderPermissionDeniedError()
+
         return True
 
 
@@ -129,17 +153,7 @@ class PipelineListView(ListView):
 
     def get_queryset(self):
         queryset = super().get_queryset()
-
-        if not self.request.user.is_superuser:
-            # Find all the table names that the user is catalogue editor for...
-            source_datasets = self.request.user.data_catalogue_edit_datasets.all()
-            source_tables = SourceTable.objects.filter(dataset__in=source_datasets)
-            pipeline_table_names = [
-                f"{source_table.schema}.{source_table.table}" for source_table in source_tables
-            ]
-            # ... and filter for pipelines that populate those tables
-            queryset = queryset.filter(table_name__in=pipeline_table_names, type="sharepoint")
-
+        queryset = filter_user_pipelines(self.request.user, queryset)
         return queryset
 
     def get_context_data(self, *args, **kwargs):
@@ -183,7 +197,7 @@ class PipelineDeleteView(IsAdminMixin, DeleteView):
         return super().delete(request, *args, **kwargs)
 
 
-class PipelineRunView(IsAdminMixin, View):
+class PipelineRunView(IsAdminOrEditorMixin, View):
     model = Pipeline
     success_url = reverse_lazy("pipelines:index")
 
@@ -203,7 +217,7 @@ class PipelineRunView(IsAdminMixin, View):
         return HttpResponseRedirect(reverse("pipelines:index"))
 
 
-class PipelineStopView(IsAdminMixin, View):
+class PipelineStopView(IsAdminOrEditorMixin, View):
     model = Pipeline
     success_url = reverse_lazy("pipelines:index")
 

--- a/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
+++ b/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
@@ -55,21 +55,19 @@
                         {% endif %}
                     </dt>
                     <dd class="govuk-summary-list__actions">
-                      {% if can_edit %}
-                        {% with object.dag_details.last_run.state as state %}
-                          {% if state == "queued" or state == "running" %}
-                            <form action="{% url 'pipelines:stop' object.id %}" method="POST">
-                              {% csrf_token %}
-                              <button class="govuk-button govuk-button--warning" data-module="govuk-button" type="submit">Stop</button>
-                            </form>
-                          {% else %}
-                            <form action="{% url 'pipelines:run' object.id %}" method="POST">
-                              {% csrf_token %}
-                              <button class="govuk-button" data-module="govuk-button" type="submit">Run</button>
-                            </form>
-                          {% endif %}
-                        {% endwith %}
-                      {% endif %}
+                      {% with object.dag_details.last_run.state as state %}
+                        {% if state == "queued" or state == "running" %}
+                          <form action="{% url 'pipelines:stop' object.id %}" method="POST">
+                            {% csrf_token %}
+                            <button class="govuk-button govuk-button--warning" data-module="govuk-button" type="submit">Stop</button>
+                          </form>
+                        {% else %}
+                          <form action="{% url 'pipelines:run' object.id %}" method="POST">
+                            {% csrf_token %}
+                            <button class="govuk-button" data-module="govuk-button" type="submit">Run</button>
+                          </form>
+                        {% endif %}
+                      {% endwith %}
                       <strong class="govuk-tag govuk-tag--grey" style="font-size: 0.7em" title="{{ object.get_schedule_display }}">
                         {{ object.schedule }}
                       </strong>

--- a/dataworkspace/dataworkspace/tests/datasets/test_pipelines.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_pipelines.py
@@ -425,4 +425,70 @@ def test_catalogue_editor_can_only_see_their_own_sharepoint_pipelines(metadata_d
     assert "Edit" not in content
     assert "Delete" not in content
     assert "View pipeline " not in content
-    assert ">Run" not in content
+    assert ">Run" in content
+
+
+@pytest.mark.django_db
+@mock.patch("dataworkspace.apps.datasets.pipelines.views.run_pipeline")
+def test_catalogue_editor_can_run_their_own_sharepoint_pipelines(mock_run, metadata_db):
+    pipeline_1 = factories.PipelineFactory.create(type="sharepoint", table_name="schema.table_1")
+    pipeline_2 = factories.PipelineFactory.create(type="sharepoint", table_name="schema.table_2")
+    pipeline_3 = factories.PipelineFactory.create(type="sql", table_name="schema.table_3")
+    pipeline_4 = factories.PipelineFactory.create(type="sql", table_name="schema.table_4")
+
+    user = factories.UserFactory.create(is_superuser=False)
+    client = Client(**get_http_sso_data(user))
+
+    source_dataset = factories.MasterDataSetFactory.create()
+    factories.SourceTableFactory(
+        dataset=source_dataset, database=metadata_db, schema="schema", table="table_1"
+    )
+    factories.SourceTableFactory(
+        dataset=source_dataset, database=metadata_db, schema="schema", table="table_3"
+    )
+    source_dataset.data_catalogue_editors.add(user)
+
+    resp_1 = client.post(reverse("pipelines:run", args=(pipeline_1.id,)), follow=True)
+    assert "Pipeline triggered successfully" in resp_1.content.decode(resp_1.charset)
+
+    resp_2 = client.post(reverse("pipelines:run", args=(pipeline_2.id,)), follow=True)
+    assert "Pipeline triggered successfully" not in resp_2.content.decode(resp_2.charset)
+
+    resp_3 = client.post(reverse("pipelines:run", args=(pipeline_3.id,)), follow=True)
+    assert "Pipeline triggered successfully" not in resp_3.content.decode(resp_3.charset)
+
+    resp_4 = client.post(reverse("pipelines:run", args=(pipeline_4.id,)), follow=True)
+    assert "Pipeline triggered successfully" not in resp_4.content.decode(resp_4.charset)
+
+
+@pytest.mark.django_db
+@mock.patch("dataworkspace.apps.datasets.pipelines.views.stop_pipeline")
+def test_catalogue_editor_can_stop_their_own_sharepoint_pipelines(mock_stop, metadata_db):
+    pipeline_1 = factories.PipelineFactory.create(type="sharepoint", table_name="schema.table_1")
+    pipeline_2 = factories.PipelineFactory.create(type="sharepoint", table_name="schema.table_2")
+    pipeline_3 = factories.PipelineFactory.create(type="sql", table_name="schema.table_3")
+    pipeline_4 = factories.PipelineFactory.create(type="sql", table_name="schema.table_4")
+
+    user = factories.UserFactory.create(is_superuser=False)
+    client = Client(**get_http_sso_data(user))
+
+    source_dataset = factories.MasterDataSetFactory.create()
+    factories.SourceTableFactory(
+        dataset=source_dataset, database=metadata_db, schema="schema", table="table_1"
+    )
+    factories.SourceTableFactory(
+        dataset=source_dataset, database=metadata_db, schema="schema", table="table_3"
+    )
+    source_dataset.data_catalogue_editors.add(user)
+
+    resp_1 = client.post(reverse("pipelines:stop", args=(pipeline_1.id,)), follow=True)
+    assert "Pipeline stopped successfully" in resp_1.content.decode(resp_1.charset)
+
+    resp_2 = client.post(reverse("pipelines:stop", args=(pipeline_2.id,)), follow=True)
+    assert "Pipeline stopped successfully" not in resp_2.content.decode(resp_2.charset)
+
+    resp_3 = client.post(reverse("pipelines:stop", args=(pipeline_3.id,)), follow=True)
+    assert "Pipeline stopped successfully" not in resp_3.content.decode(resp_3.charset)
+
+    resp_4 = client.post(reverse("pipelines:stop", args=(pipeline_4.id,)), follow=True)
+    assert "Pipeline stopped successfully" not in resp_4.content.decode(resp_4.charset)


### PR DESCRIPTION
### Description of change

This adds the ability for catalogue editors to start and stop their own Sharepoint pipelines, or more specifically, Sharepoint pipelines that populate the tables in datasets for which they are catalogue editors for.

This is part of ongoing work to distribute responsibility for managing data.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?