### PR TITLE
fix the link to related dashboard on catalogue page

### DIFF
--- a/dataworkspace/dataworkspace/templates/partials/related_data_link.html
+++ b/dataworkspace/dataworkspace/templates/partials/related_data_link.html
@@ -1,2 +1,3 @@
 <a class="govuk-link {% if css_classname %}{{ css_classname }}{% else %}related-data{% endif %}"
-   href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}"</a>
+   href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}">
+</a>


### PR DESCRIPTION
### Description of change

Fix the link to related dashboard content for data source catalogue page with less than four linked dashboards.  
![image](https://github.com/user-attachments/assets/1ad0a43b-0d07-4a07-9dac-7142f12f2a5f)


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?