### PR TITLE
feat: add ids to table names in pipelines page

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
+++ b/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
@@ -28,7 +28,7 @@
                 {% for object in object_list %}
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__value">
-                        <h2>{{ object.table_name }}</h2>
+                        <h2 id="{{ object.table_name }}">{{ object.table_name }}</h2>
                         {% with object.dag_details as dag %}
                           {% if dag is None %}
                             <p>Error fetching information for this pipeline</p>

--- a/dataworkspace/dataworkspace/tests/datasets/test_pipelines.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_pipelines.py
@@ -372,6 +372,8 @@ def test_superuser_can_see_pipelines():
     assert "Add new pipeline" in content
     assert pipeline_1.table_name in content
     assert pipeline_2.table_name in content
+    assert f'id="{ pipeline_1.table_name }"' in content
+    assert f'id="{ pipeline_2.table_name }"' in content
 
 
 @pytest.mark.django_db
@@ -464,6 +466,7 @@ def test_non_admin_user_can_only_see_their_own_sharepoint_pipelines(
     assert "You do not have access to any pipelines." not in content
     assert "Add new pipeline" not in content
     assert escape_quote_html(pipeline_1.table_name) in content
+    assert f'id="{ escape_quote_html(pipeline_1.table_name) }"' in content
     assert escape_quote_html(pipeline_2.table_name) not in content
     assert escape_quote_html(pipeline_3.table_name) not in content
     assert escape_quote_html(pipeline_4.table_name) not in content


### PR DESCRIPTION
### Description of change
This adds an id attribute to each pipeline in the /pipelines page.

This is so links from other pages can be linked directly to each pipeline. Specifically, in a future change, we expect to add links from catalogue pages to the pipelines that populate their tables.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?