### PR TITLE
feat: link to /pipelines from "Update or restore" page of Sharepoint-populated

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/manager/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/manager/forms.py
@@ -22,7 +22,7 @@ class SourceTableUploadForm(GOVUKDesignSystemForm):
         widget=GOVUKDesignSystemFileInputWidget(
             label_is_heading=True,
             heading="h2",
-            heading_class="govuk-heading-s",
+            heading_class="govuk-heading-m",
             extra_label_classes="govuk-!-font-weight-bold",
             show_selected_file=True,
             attrs={"accept": "text/csv"},

--- a/dataworkspace/dataworkspace/apps/datasets/manager/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/manager/views.py
@@ -31,6 +31,7 @@ from dataworkspace.apps.datasets.manager.forms import (
     SourceTableUploadForm,
 )
 from dataworkspace.apps.datasets.views import EditBaseView
+from dataworkspace.apps.datasets.models import Pipeline
 from dataworkspace.apps.your_files.models import UploadedTable
 
 
@@ -53,6 +54,14 @@ class DatasetManageSourceTableView(WaffleFlagMixin, EditBaseView, FormView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx["source"] = self._get_source()
+        ctx["pipeline"] = (
+            Pipeline.objects.all()
+            .filter(
+                table_name__in=Pipeline.possible_pipeline_table_names((ctx["source"],)),
+                type="sharepoint",
+            )
+            .first()
+        )
         return ctx
 
     def form_valid(self, form):

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -3006,6 +3006,31 @@ class Pipeline(TimeStampedUserModel):
     def __str__(self):
         return self.dag_id
 
+    @staticmethod
+    def possible_pipeline_table_names(source_tables):
+        """
+        Returns all possible pipeline names that populate the passed source tables.
+
+        This works around the historical awkwardness resulting from the fact that source tables
+        are defined by separate schema and table names, but pipelines are defined by combined
+        possibly-quoted fully qualified table names, i.e. schema.table, "schema".table, schema."table"
+        or "schema"."table"
+        """
+
+        def quote(identifier):
+            return '"' + identifier.replace('"', '""') + '"'
+
+        return [
+            possibly_quoted_name
+            for source_table in source_tables
+            for possibly_quoted_name in [
+                source_table.schema + "." + source_table.table,
+                source_table.schema + "." + quote(source_table.table),
+                quote(source_table.schema) + "." + source_table.table,
+                quote(source_table.schema) + "." + quote(source_table.table),
+            ]
+        ]
+
     @property
     def dag_id(self):
         # Strip double quotes from the table name to:

--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
@@ -26,10 +26,6 @@ from dataworkspace.apps.explorer.schema import get_user_schema_info
 logger = logging.getLogger("app")
 
 
-def quote(identifier):
-    return '"' + identifier.replace('"', '""') + '"'
-
-
 def filter_user_pipelines(user, pipelines_qs):
     if not user.is_superuser:
         # Find all the table names that the user is catalogue editor/IAM/IAO for...
@@ -40,17 +36,10 @@ def filter_user_pipelines(user, pipelines_qs):
         source_tables = SourceTable.objects.filter(dataset__in=source_datasets)
         # and filter for pipelines that populate those tables. It's a bit awkward because the
         # piplines allow both quoted and non-quoted names
-        pipeline_table_names = [
-            possibly_quoted_name
-            for source_table in source_tables
-            for possibly_quoted_name in [
-                source_table.schema + "." + source_table.table,
-                source_table.schema + "." + quote(source_table.table),
-                quote(source_table.schema) + "." + source_table.table,
-                quote(source_table.schema) + "." + quote(source_table.table),
-            ]
-        ]
-        pipelines_qs = pipelines_qs.filter(table_name__in=pipeline_table_names, type="sharepoint")
+        pipelines_qs = pipelines_qs.filter(
+            table_name__in=Pipeline.possible_pipeline_table_names(source_tables),
+            type="sharepoint",
+        )
 
     return pipelines_qs
 

--- a/dataworkspace/dataworkspace/templates/datasets/manager/manage_source_table.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manager/manage_source_table.html
@@ -49,33 +49,42 @@
     </div>
   </div>
   {% flag SECURITY_CLASSIFICATION_FLAG %}
-  <div class="govuk-grid-row govuk-grid-column-two-thirds">
-  <h1 class="govuk-heading-s">Government Security Classification</h1>
-    <p class="govuk-body govuk-body-m">
-      This data is currently classified as {% if not source.dataset.government_security_classification %}
-      <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
-      {% else %}{% if source.dataset.get_government_security_classification_display == "OFFICIAL" %}
-        <strong
-          class="govuk-tag govuk-tag--blue">{{ source.dataset.get_government_security_classification_display|title }}</strong>
-      {% else %}
-        <strong
-          class="govuk-tag govuk-tag--red govuk-!-margin-bottom-4">{{ source.dataset.get_government_security_classification_display|title }}
-          {% if source.dataset.sensitivity.all %}
-            {% for sensitivity in source.dataset.sensitivity.all %}
-              {% if not forloop.first %}<span>and {% endif %}</span>{{ sensitivity|title }}
-            {% endfor %}
-          {% endif %}
-        </strong>
-      {% endif %}
-    {% endif %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <h2 class="govuk-heading-m">Government Security Classification</h2>
+      <p class="govuk-body govuk-body-m">
+        This data is currently classified as {% if not source.dataset.government_security_classification %}
+        <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
+        {% else %}{% if source.dataset.get_government_security_classification_display == "OFFICIAL" %}
+          <strong
+            class="govuk-tag govuk-tag--blue">{{ source.dataset.get_government_security_classification_display|title }}</strong>
+        {% else %}
+          <strong
+            class="govuk-tag govuk-tag--red govuk-!-margin-bottom-4">{{ source.dataset.get_government_security_classification_display|title }}
+            {% if source.dataset.sensitivity.all %}
+              {% for sensitivity in source.dataset.sensitivity.all %}
+                {% if not forloop.first %}<span>and {% endif %}</span>{{ sensitivity|title }}
+              {% endfor %}
+            {% endif %}
+          </strong>
+        {% endif %}
+        {% endif %}
       <br>If this is no longer correct, please update the classification on
-      the <a href="{% url 'datasets:edit_dataset' source.dataset.id %}">Manage screen.</a>
-    </p>
+      the <a href="{% url 'datasets:edit_dataset' source.dataset.id %}">Manage&nbsp;screen.</a>
+      </p>
+    </div>
   </div>
   {% endflag %}
+  {% if pipeline %}
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  <h2 class="govuk-heading-m">Manage pipeline</h2>
+  <p class="govuk-body govuk-body-m">You can trigger the pipeline that populates this table from the <a class="govuk-link govuk-link--no-visited-state" href="{% url 'pipelines:index' %}#{{ pipeline.table_name }}">Pipelines&nbsp;page.</a></p>
+  {% endif %}
   {% block success_banner %}{% endblock %}
-  <div class="govuk-grid-row govuk-!-margin-top-6" id="update">
+  <div class="govuk-grid-row" id="update">
     <div class="govuk-grid-column-two-thirds">
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
       <form method="POST" enctype="multipart/form-data">
         {% csrf_token %}
         {% include 'design_system/error_summary.html' %}
@@ -84,9 +93,10 @@
       </form>
     </div>
   </div>
-  <div class="govuk-grid-row govuk-!-margin-top-6" id="update">
+  <div class="govuk-grid-row" id="update">
     <div class="govuk-grid-column-full" style="overflow-x: auto;">
-      <h1 class="govuk-heading-s">Restore from a previous version</h1>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <h2 class="govuk-heading-m">Restore from a previous version</h2>
       <table class="govuk-table">
         <thead>
         <tr class="govuk-table__row">
@@ -105,7 +115,7 @@
                 {{ version.created_by.email }}
               </td>
               <td class="govuk-table__cell">
-                <a href="{% url 'datasets:manager:restore-table' pk=source.dataset_id source_uuid=source.id version_id=version.id %}" class="govuk-link">Restore</a>
+                <a href="{% url 'datasets:manager:restore-table' pk=source.dataset_id source_uuid=source.id version_id=version.id %}" class="govuk-link govuk-link--no-visited-state">Restore</a>
               </td>
             </tr>
           {% empty %}


### PR DESCRIPTION
### Description of change

This links to the pipeline in the /pipelines page from the "Update or restore" page for a table, if there is a Sharepoint pipeline that populates that table. This also does a few tidy ups:

- Tidies up some spacing by correctly nesting GOV.UK Design System rows and columns
- Increases the visible heading size to medium for second-level headings - small seemed a bit too small given the size of the text
- Sets second-level headings to be h2 from h1
- Introduces horizontal lines between sections in the "Update or restore" page - it was already a bit unclear what went with what, and that would have only gotten worse with the extra link .

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?