### PR TITLE
feat: allow catalogue editors, IAMs and IAOs to run and stop SQL pipelines

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/manager/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/manager/views.py
@@ -58,7 +58,6 @@ class DatasetManageSourceTableView(WaffleFlagMixin, EditBaseView, FormView):
             Pipeline.objects.all()
             .filter(
                 table_name__in=Pipeline.possible_pipeline_table_names((ctx["source"],)),
-                type="sharepoint",
             )
             .first()
         )

--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
@@ -38,7 +38,6 @@ def filter_user_pipelines(user, pipelines_qs):
         # piplines allow both quoted and non-quoted names
         pipelines_qs = pipelines_qs.filter(
             table_name__in=Pipeline.possible_pipeline_table_names(source_tables),
-            type="sharepoint",
         )
 
     return pipelines_qs

--- a/dataworkspace/dataworkspace/tests/datasets/test_pipelines.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_pipelines.py
@@ -428,7 +428,7 @@ def escape_quote_html(string):
         lambda schema, table: f'"{schema}"."{table}"',
     ],
 )
-def test_non_admin_user_can_only_see_their_own_sharepoint_pipelines(
+def test_non_admin_user_can_only_see_their_own_sharepoint_and_sql_pipelines(
     metadata_db,
     give_user_management_access_to_dataset,
     quote,
@@ -468,7 +468,8 @@ def test_non_admin_user_can_only_see_their_own_sharepoint_pipelines(
     assert escape_quote_html(pipeline_1.table_name) in content
     assert f'id="{ escape_quote_html(pipeline_1.table_name) }"' in content
     assert escape_quote_html(pipeline_2.table_name) not in content
-    assert escape_quote_html(pipeline_3.table_name) not in content
+    assert escape_quote_html(pipeline_3.table_name) in content
+    assert f'id="{ escape_quote_html(pipeline_3.table_name) }"' in content
     assert escape_quote_html(pipeline_4.table_name) not in content
 
     assert "Edit" not in content
@@ -496,7 +497,7 @@ def test_non_admin_user_can_only_see_their_own_sharepoint_pipelines(
     ],
 )
 @mock.patch("dataworkspace.apps.datasets.pipelines.views.run_pipeline")
-def test_non_admin_user_can_run_their_own_sharepoint_pipelines(
+def test_non_admin_user_can_run_their_own_sharepoint_and_sql_pipelines(
     mock_run,
     metadata_db,
     give_user_management_access_to_dataset,
@@ -535,7 +536,7 @@ def test_non_admin_user_can_run_their_own_sharepoint_pipelines(
     assert "Pipeline triggered successfully" not in resp_2.content.decode(resp_2.charset)
 
     resp_3 = client.post(reverse("pipelines:run", args=(pipeline_3.id,)), follow=True)
-    assert "Pipeline triggered successfully" not in resp_3.content.decode(resp_3.charset)
+    assert "Pipeline triggered successfully" in resp_3.content.decode(resp_3.charset)
 
     resp_4 = client.post(reverse("pipelines:run", args=(pipeline_4.id,)), follow=True)
     assert "Pipeline triggered successfully" not in resp_4.content.decode(resp_4.charset)
@@ -560,7 +561,7 @@ def test_non_admin_user_can_run_their_own_sharepoint_pipelines(
     ],
 )
 @mock.patch("dataworkspace.apps.datasets.pipelines.views.stop_pipeline")
-def test_non_admin_user_can_stop_their_own_sharepoint_pipelines(
+def test_non_admin_user_can_stop_their_own_sharepoint_and_sql_pipelines(
     mock_stop,
     metadata_db,
     give_user_management_access_to_dataset,
@@ -599,7 +600,7 @@ def test_non_admin_user_can_stop_their_own_sharepoint_pipelines(
     assert "Pipeline stopped successfully" not in resp_2.content.decode(resp_2.charset)
 
     resp_3 = client.post(reverse("pipelines:stop", args=(pipeline_3.id,)), follow=True)
-    assert "Pipeline stopped successfully" not in resp_3.content.decode(resp_3.charset)
+    assert "Pipeline stopped successfully" in resp_3.content.decode(resp_3.charset)
 
     resp_4 = client.post(reverse("pipelines:stop", args=(pipeline_4.id,)), follow=True)
     assert "Pipeline stopped successfully" not in resp_4.content.decode(resp_4.charset)

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4466,14 +4466,14 @@ class TestDatasetManagerViews:
             published=True, user_access_type=UserAccessType.REQUIRES_AUTHENTICATION
         )
         source_1 = factories.SourceTableFactory.create(
-            dataset=dataset_1, schema="test", table="table1"
+            dataset=dataset_1, schema="test", table="sql_table1"
         )
 
         dataset_2 = factories.MasterDataSetFactory.create(
             published=True, user_access_type=UserAccessType.REQUIRES_AUTHENTICATION
         )
         source_2 = factories.SourceTableFactory.create(
-            dataset=dataset_2, schema="test", table="table2"
+            dataset=dataset_2, schema="test", table="sharepoint_table2"
         )
 
         url_1 = reverse("datasets:manager:manage-source-table", args=(dataset_1.id, source_1.id))
@@ -4489,24 +4489,28 @@ class TestDatasetManagerViews:
         content = response.content.decode(response.charset)
         assert "Manage pipeline" not in content
 
-        factories.PipelineFactory.create(type="sharepoint", table_name="schema.table1")
+        factories.PipelineFactory.create(type="sharepoint", table_name="schema.sql_table1")
         response = client.get(url_1)
         content = response.content.decode(response.charset)
         assert "Manage pipeline" not in content
 
-        factories.PipelineFactory.create(type="sql", table_name="test.table1")
+        factories.PipelineFactory.create(type="sql", table_name="test.sql_table1")
         response = client.get(url_1)
         content = response.content.decode(response.charset)
-        assert "Manage pipeline" not in content
+        assert "Manage pipeline" in content
 
-        factories.PipelineFactory.create(type="sharepoint", table_name="test.table2")
+        # The pipelines page has elements with the ID of the pipeline,
+        # And we assert that we link to the right pipeline.
+        assert "#test.sql_table1" in content
+
+        factories.PipelineFactory.create(type="sharepoint", table_name="test.sharepoint_table2")
         response = client.get(url_2)
         content = response.content.decode(response.charset)
         assert "Manage pipeline" in content
 
         # The pipelines page has elements with the ID of the pipeline,
         # And we assert that we link to the right pipeline.
-        assert "#test.table2" in content
+        assert "#test.sharepoint_table2" in content
 
     @override_flag(settings.DATA_UPLOADER_UI_FLAG, active=True)
     @pytest.mark.django_db


### PR DESCRIPTION
### Description of change

This links to the pipeline in the /pipelines page from the "Update or restore" page for a table, if there is an SQL pipeline that populates that table.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?