### PR TITLE
feat: human readable cron in pipelines page

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -14,6 +14,7 @@ from typing import List, Optional
 
 import waffle
 from botocore.exceptions import ClientError
+from cron_descriptor import get_description
 from django import forms
 from django.apps import apps
 from django.conf import settings
@@ -3049,6 +3050,30 @@ class Pipeline(TimeStampedUserModel):
 
     def get_absolute_url(self):
         return reverse(f"pipelines:edit-{self.type}", args=(self.id,))
+
+    def get_schedule_display(self):
+        if self.schedule == PipelineScheduleType.ONCE:
+            schedule_display = "Runs manually"
+        elif self.schedule == PipelineScheduleType.DAILY:
+            schedule_display = "Runs daily at midnight"
+        elif self.schedule == PipelineScheduleType.WEEKLY:
+            schedule_display = "Runs on Sundays at midnight"
+        elif self.schedule == PipelineScheduleType.FRIDAYS:
+            schedule_display = "Runs on Fridays at midnight"
+        elif self.schedule == PipelineScheduleType.MONTHLY:
+            schedule_display = "Runs on the first of every month at midnight"
+        elif self.schedule == PipelineScheduleType.YEARLY:
+            schedule_display = "Runs every January 1st at midnight"
+        elif self.schedule == PipelineScheduleType.CUSTOM:
+            description = (
+                get_description(self.custom_schedule)
+                .replace(" AM", "\xa0AM")
+                .replace(" PM", "\xa0PM")
+            )
+            schedule_display = "Runs " + description[0].lower() + description[1:]
+        else:
+            schedule_display = self.schedule
+        return schedule_display
 
     def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         if self.id is not None and (

--- a/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
+++ b/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
@@ -68,10 +68,10 @@
                           </form>
                         {% endif %}
                       {% endwith %}
-                      <strong class="govuk-tag govuk-tag--grey" style="font-size: 0.7em" title="{{ object.get_schedule_display }}">
-                        {{ object.schedule }}
+                      <strong class="govuk-tag govuk-tag--grey" style="font-size: 0.7em">
+                        {{ object.get_schedule_display }}
                       </strong>
-                      <strong class="govuk-tag govuk-tag--grey" style="font-size: 0.7em" title="{{ object.type }}">
+                      <strong class="govuk-tag govuk-tag--grey" style="font-size: 0.7em">
                         {{ object.type }}
                       </strong>
                     </dd>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,8 @@ amqp==5.1.1
     #   kombu
 appdirs==1.4.4
     # via pyppeteer
+appnope==0.1.4
+    # via ipython
 asgiref==3.7.2
     # via
     #   -r requirements.txt
@@ -138,6 +140,8 @@ colorama==0.4.6
     # via djlint
 coverage==5.4
     # via pytest-cov
+cron-descriptor==1.4.5
+    # via -r requirements.txt
 cryptography==44.0.1
     # via -r requirements.txt
 debugpy==1.2.1
@@ -264,7 +268,6 @@ greenlet==3.2.2
     # via
     #   -r requirements.txt
     #   gevent
-    #   sqlalchemy
 h11==0.16.0
     # via wsproto
 hawk-server-asyncio==0.0.13

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ bleach
 boto3
 celery-redbeat
 celery
+cron-descriptor
 cryptography
 dj-database-url
 django-admin-inline-paginator

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,6 +78,8 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
+cron-descriptor==1.4.5
+    # via -r requirements.in
 cryptography==44.0.1
     # via -r requirements.in
 dj-database-url==0.5.0


### PR DESCRIPTION
### Description of change

This makes the schedule descriptions on the pipelines page more human readable and uses the Cron Descriptor library to address the issue of cron expressions appearing for custom schedules.

These changes allow users to see when each pipeline is run, especially for pipelines on custom schedules, which previously were not human readable.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Have E2E tests been added to cover any React changes?
* [ ] Have Accessibility tests been added to cover any React changes?