### PR TITLE
Add matchbox to DNS rewrite rules

### DIFF
--- a/dns-rewrite-proxy/nameserver.py
+++ b/dns-rewrite-proxy/nameserver.py
@@ -46,9 +46,10 @@ async def async_main():
 
     start = DnsProxy(
         rules=(
-            # The arango host in the public zone will already correctly
+            # For arango and matchbox, the host in the public zone will already correctly
             # resolve to the private IP, so we pass that through
             (r"^(arango\." + public_zone + ")$", r"\1"),
+            (r"^(matchbox\." + public_zone + ")$", r"\1"),
             # ... other public zone hosts should resolve to the IP of the
             # private zone, e.g. gitlab
             (r"^(.+)\." + public_zone + "$", r"\1." + private_zone),


### PR DESCRIPTION
### Description of change

The PR updates the DNS rewrite proxy container rules to ignore Matchbox rewrite from public to private hosted zone. 
